### PR TITLE
Feature/death

### DIFF
--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -150,4 +150,4 @@ text = "state:"
 [connection signal="pressed" from="BottomBar/MovesMenu/Move2" to="." method="_on_move_pressed" binds= [1]]
 [connection signal="pressed" from="BottomBar/MovesMenu/Move3" to="." method="_on_move_pressed" binds= [2]]
 [connection signal="pressed" from="BottomBar/MovesMenu/Move4" to="." method="_on_move_pressed" binds= [3]]
-[connection signal="pressed" from="BottomBar/BattleStatus/ContinueButton" to="." method="_on_info_button_pressed"]
+[connection signal="pressed" from="BottomBar/BattleStatus/ContinueButton" to="." method="_on_continue_button_pressed"]

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -4,7 +4,7 @@ var turn: int = 0
 var turn_order_index: int = 0
 var battle_participants = []
 
-enum State {SELECTING_ACTION, SELECTING_ATTACK, PLAYER_ATTACK_INFO, ENEMY_ATTACK, ENEMY_ATTACK_INFO}
+enum State {SELECTING_ACTION, SELECTING_ATTACK, PLAYER_ATTACK_INFO, ENEMY_ATTACK, ENEMY_ATTACK_INFO, PLAYER_WIN, PLAYER_LOSS}
 var state: State = State.SELECTING_ACTION
 
 # Called when the node enters the scene tree for the first time.
@@ -36,6 +36,12 @@ func _update_state(new_state: State):
 		%ContinueButton.visible = false
 		%BattleStatus.visible = false
 		_render_hp()
+		if %Enemy.hp <= 0:
+			_update_state(State.PLAYER_WIN)
+			return
+		elif %Player.hp <= 0:
+			_update_state(State.PLAYER_LOSS)
+			return
 
 	if state == State.SELECTING_ACTION:
 		%PlayerPrompt.visible = true
@@ -58,6 +64,16 @@ func _update_state(new_state: State):
 		%BattleStatus.visible = true
 		%BattleStatus.text = "Enemy Attacked Player"
 		%ContinueButton.visible = true
+		%ContinueButton.grab_focus()
+	elif state == State.PLAYER_WIN:
+		%BattleStatus.visible = true
+		%BattleStatus.size.x = 255
+		%BattleStatus.text = "Player defeated Enemy"
+		%ContinueButton.grab_focus()
+	elif state == State.PLAYER_LOSS:
+		%BattleStatus.visible = true
+		%BattleStatus.size.x = 255
+		%BattleStatus.text = "Enemy defeated Player"
 		%ContinueButton.grab_focus()
 
 func _init_battle_participants():

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -76,7 +76,7 @@ func _render_hp() -> void:
 	%EnemyPanel.text = "Enemy " + str(%Enemy.hp) + " / " + str(%Enemy.max_hp)
 	%PlayerPanel.text = "Player " + str(%Player.hp) + " / " + str(%Player.max_hp)
 
-func _on_info_button_pressed() -> void:
+func _on_continue_button_pressed() -> void:
 	if state == State.PLAYER_ATTACK_INFO:
 		_update_state(State.ENEMY_ATTACK)
 	elif state == State.ENEMY_ATTACK_INFO:

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -97,6 +97,8 @@ func _on_continue_button_pressed() -> void:
 		_update_state(State.ENEMY_ATTACK)
 	elif state == State.ENEMY_ATTACK_INFO:
 		_update_state(State.SELECTING_ACTION)
+	elif state == State.PLAYER_WIN || state == State.PLAYER_LOSS:
+		get_tree().quit()
 
 func _on_attack_pressed() -> void:
 	if state == State.SELECTING_ACTION:

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -63,12 +63,10 @@ func _update_state(new_state: State):
 		%ContinueButton.grab_focus()
 	elif state == State.PLAYER_WIN:
 		%BattleStatus.visible = true
-		%BattleStatus.size.x = 255
 		%BattleStatus.text = "Player defeated Enemy"
 		%ContinueButton.grab_focus()
 	elif state == State.PLAYER_LOSS:
 		%BattleStatus.visible = true
-		%BattleStatus.size.x = 255
 		%BattleStatus.text = "Enemy defeated Player"
 		%ContinueButton.grab_focus()
 

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -4,7 +4,7 @@ var turn: int = 0
 var turn_order_index: int = 0
 var battle_participants = []
 
-enum State {SELECTING_ACTION, SELECTING_ATTACK, PLAYER_ATTACK_INFO, ENEMY_ATTACK, ENEMY_ATTACK_INFO, PLAYER_WIN, PLAYER_LOSS}
+enum State {SELECTING_ACTION, SELECTING_ATTACK, PLAYER_ATTACK_INFO, ENEMY_ATTACK, ENEMY_ATTACK_INFO, GAME_END}
 var state: State = State.SELECTING_ACTION
 
 # Called when the node enters the scene tree for the first time.
@@ -35,15 +35,16 @@ func _update_state(new_state: State):
 		%BattleStatus.visible = false
 		_render_hp()
 		if %Enemy.hp <= 0:
-			_update_state(State.PLAYER_WIN)
+			%BattleStatus.text = "Player defeated Enemy"
+			_update_state(State.GAME_END)
 			return
 		elif %Player.hp <= 0:
-			_update_state(State.PLAYER_LOSS)
+			%BattleStatus.text = "Enemy defeated Player"
+			_update_state(State.GAME_END)
 			return
 
 	if state == State.SELECTING_ACTION:
 		%PlayerPrompt.visible = true
-		#%PlayerPrompt.size.x = 255
 		%PlayerPrompt.text = "What will PLAYER do?"
 		%Action.visible = true
 		%Action.get_child(0).grab_focus()
@@ -61,13 +62,8 @@ func _update_state(new_state: State):
 		%BattleStatus.visible = true
 		%BattleStatus.text = "Enemy Attacked Player"
 		%ContinueButton.grab_focus()
-	elif state == State.PLAYER_WIN:
+	elif state == State.GAME_END:
 		%BattleStatus.visible = true
-		%BattleStatus.text = "Player defeated Enemy"
-		%ContinueButton.grab_focus()
-	elif state == State.PLAYER_LOSS:
-		%BattleStatus.visible = true
-		%BattleStatus.text = "Enemy defeated Player"
 		%ContinueButton.grab_focus()
 
 func _init_battle_participants():
@@ -91,7 +87,7 @@ func _on_continue_button_pressed() -> void:
 		_update_state(State.ENEMY_ATTACK)
 	elif state == State.ENEMY_ATTACK_INFO:
 		_update_state(State.SELECTING_ACTION)
-	elif state == State.PLAYER_WIN || state == State.PLAYER_LOSS:
+	elif state == State.GAME_END:
 		get_tree().quit()
 
 func _on_attack_pressed() -> void:

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -29,11 +29,9 @@ func _update_state(new_state: State):
 	if old_state == State.SELECTING_ACTION:
 		%PlayerPrompt.visible = false
 		%Action.visible = false
-		
 	elif old_state == State.SELECTING_ATTACK:
 		%MovesMenu.visible = false
 	elif old_state == State.PLAYER_ATTACK_INFO || old_state == State.ENEMY_ATTACK_INFO:
-		%ContinueButton.visible = false
 		%BattleStatus.visible = false
 		_render_hp()
 		if %Enemy.hp <= 0:
@@ -58,12 +56,10 @@ func _update_state(new_state: State):
 	elif state == State.PLAYER_ATTACK_INFO:
 		%BattleStatus.visible = true
 		%BattleStatus.text = "Player Attacked Enemy"
-		%ContinueButton.visible = true
 		%ContinueButton.grab_focus()
 	elif state == State.ENEMY_ATTACK_INFO:
 		%BattleStatus.visible = true
 		%BattleStatus.text = "Enemy Attacked Player"
-		%ContinueButton.visible = true
 		%ContinueButton.grab_focus()
 	elif state == State.PLAYER_WIN:
 		%BattleStatus.visible = true


### PR DESCRIPTION
# Summary
- Adds a new state `GAME_END`
- When leaving the `PLAYER_ATTACK_INFO` or `ENEMY_ATTACK_INFO` states, we check to see if either the player or enemy has 0 HP
  - If one of them does have 0 HP, `%BattleStatus.text` is updated to show the winner and the state is set to `GAME_END` 
- In `GAME_END` state, pressing the continue button will quit the game