### PR TITLE
Adjust player panel on battle start

### DIFF
--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=20 format=3 uid="uid://bpa0ix5wqg68n"]
+[gd_scene load_steps=21 format=3 uid="uid://bpa0ix5wqg68n"]
 
 [ext_resource type="Script" uid="uid://bc6wki4amvsx" path="res://scripts/battle.gd" id="1_a12nh"]
 [ext_resource type="Texture2D" uid="uid://b2eajagu6j5pi" path="res://assets/sprites/pokemon_rpg_screen_grayscale.png" id="1_dn72j"]
 [ext_resource type="Theme" uid="uid://bb5xdt6d0xc8h" path="res://assets/themes/main.tres" id="2_p1qf1"]
 [ext_resource type="StyleBox" uid="uid://dwb68ajbfeqp0" path="res://assets/styles/normal_sbf.tres" id="4_lpir7"]
+[ext_resource type="Script" uid="uid://yal21vgfjdjg" path="res://scripts/health_panel.gd" id="5_61i1y"]
 [ext_resource type="PackedScene" uid="uid://dspy5d5yn1fxj" path="res://scenes/battle_participant.tscn" id="5_lpir7"]
 [ext_resource type="Script" uid="uid://cstx4ogvno1si" path="res://scripts/enemy.gd" id="6_6vh42"]
 [ext_resource type="Script" uid="uid://cyqywjpbta4p8" path="res://scripts/monster.gd" id="6_djc8l"]
@@ -170,13 +171,16 @@ text = "Enemy"
 
 [node name="PlayerPanel" type="Label" parent="HealthPanels"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(96, 0)
 offset_left = 145.0
 offset_top = 56.0
 offset_right = 241.0
 offset_bottom = 88.0
+size_flags_horizontal = 0
 theme = ExtResource("2_p1qf1")
 theme_override_styles/normal = ExtResource("4_lpir7")
 text = "Player"
+script = ExtResource("5_61i1y")
 
 [node name="Player" parent="." instance=ExtResource("5_lpir7")]
 unique_name_in_owner = true

--- a/scripts/health_panel.gd
+++ b/scripts/health_panel.gd
@@ -3,7 +3,6 @@ extends Label
 # value is in pixels -- this means the right edge of the label is at least 7
 # pixels away from the edge of the window
 const BUFFER: int = 7
-var _initialized: bool = false
 
 func _ready():
 	call_deferred("adjust_position")

--- a/scripts/health_panel.gd
+++ b/scripts/health_panel.gd
@@ -1,0 +1,20 @@
+extends Label
+
+# value is in pixels -- this means the right edge of the label is at least 7
+# pixels away from the edge of the window
+const BUFFER: int = 7
+var _initialized: bool = false
+
+func _ready():
+	call_deferred("adjust_position")
+
+func adjust_position():
+	var viewport_width: int = ProjectSettings.get_setting("display/window/size/viewport_width")
+	var viewport_scale: int = ProjectSettings.get_setting("display/window/stretch/scale")
+	var viewport_pixel_width: int = viewport_width / viewport_scale
+
+	var label_right_edge: int = position.x + size.x
+	var overflow: int = (label_right_edge - viewport_pixel_width) + BUFFER
+
+	if overflow > 0:
+		position.x -= overflow

--- a/scripts/health_panel.gd.uid
+++ b/scripts/health_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://yal21vgfjdjg


### PR DESCRIPTION
## Summary
 - Attach `scripts/health_panel.gd` to Player health panel (`scenes/battle.tscn`)
 - On battle start, determine how close the Player health panel is to the edge of the screen. Move it so it is at least 7 pixels away from the edge of the screen

### After Change
![Screenshot 2025-06-03 at 9 06 11 PM](https://github.com/user-attachments/assets/00e9d412-14b1-4047-b33b-f81849d4c770)

### Before Change
![Screenshot 2025-06-03 at 9 06 47 PM](https://github.com/user-attachments/assets/0bcbf19c-28f9-46a8-b37e-5651dee1dab0)
