### PR TITLE
Color Code HP Sliders

### DIFF
--- a/assets/styles/hp_bar_background_sbf.tres
+++ b/assets/styles/hp_bar_background_sbf.tres
@@ -1,0 +1,9 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://biow57dl4dwgl"]
+
+[resource]
+bg_color = Color(0.0705882, 0.305882, 0.537255, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.0705882, 0.305882, 0.537255, 1)

--- a/assets/styles/hp_foreground_green_sbf.tres
+++ b/assets/styles/hp_foreground_green_sbf.tres
@@ -1,0 +1,9 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://bg1kpjok5bcns"]
+
+[resource]
+bg_color = Color(0.243137, 0.537255, 0.282353, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.0705882, 0.305882, 0.537255, 1)

--- a/assets/styles/hp_foreground_red_sbf.tres
+++ b/assets/styles/hp_foreground_red_sbf.tres
@@ -1,0 +1,9 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://b16q1x2hswiv3"]
+
+[resource]
+bg_color = Color(0.894118, 0.231373, 0.266667, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.0705882, 0.305882, 0.537255, 1)

--- a/assets/styles/hp_foreground_yellow_sbf.tres
+++ b/assets/styles/hp_foreground_yellow_sbf.tres
@@ -1,0 +1,9 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://copt7xkvufmol"]
+
+[resource]
+bg_color = Color(0.996078, 0.682353, 0.203922, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.0705882, 0.305882, 0.537255, 1)

--- a/assets/themes/main.tres
+++ b/assets/themes/main.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=12 format=3 uid="uid://bb5xdt6d0xc8h"]
+[gd_resource type="Theme" load_steps=14 format=3 uid="uid://bb5xdt6d0xc8h"]
 
 [ext_resource type="StyleBox" uid="uid://dv2ftdeiv2dr3" path="res://assets/styles/focus_sbf.tres" id="2_7mpy8"]
 [ext_resource type="StyleBox" uid="uid://dlv23d40rqvlb" path="res://assets/styles/normal_sbf_rich_text_label.tres" id="2_upbfd"]
@@ -8,7 +8,9 @@
 [ext_resource type="StyleBox" uid="uid://jb04x3reseor" path="res://assets/styles/scrollbar_focus_sbf.tres" id="5_keqi6"]
 [ext_resource type="StyleBox" uid="uid://c854nh0fccd54" path="res://assets/styles/border_color_sbf.tres" id="6_f4hnv"]
 [ext_resource type="StyleBox" uid="uid://dq5bgcynd5yxl" path="res://assets/styles/scrollbar_background_sbf.tres" id="6_keqi6"]
+[ext_resource type="StyleBox" uid="uid://biow57dl4dwgl" path="res://assets/styles/hp_bar_background_sbf.tres" id="7_ewgrn"]
 [ext_resource type="FontFile" uid="uid://hk526fxfu4wa" path="res://assets/fonts/LoRes 9 OT Wide Regular.ttf" id="7_upbfd"]
+[ext_resource type="StyleBox" uid="uid://bg1kpjok5bcns" path="res://assets/styles/hp_foreground_green_sbf.tres" id="8_vv0yi"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fjh1m"]
 content_margin_left = 3.0
@@ -66,6 +68,8 @@ NoBorderLabel/base_type = &"Label"
 NoBorderLabel/constants/line_spacing = 6
 NoBorderLabel/styles/normal = SubResource("StyleBoxFlat_fjh1m")
 Panel/styles/panel = ExtResource("2_upbfd")
+ProgressBar/styles/background = ExtResource("7_ewgrn")
+ProgressBar/styles/fill = ExtResource("8_vv0yi")
 RedTextLabel/base_type = &"NoBorderLabel"
 RedTextLabel/colors/font_color = Color(0.635294, 0.14902, 0.2, 1)
 RichTextLabel/font_sizes/normal_font_size = 9

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -1,12 +1,10 @@
-[gd_scene load_steps=19 format=3 uid="uid://bpa0ix5wqg68n"]
+[gd_scene load_steps=17 format=3 uid="uid://bpa0ix5wqg68n"]
 
 [ext_resource type="Script" uid="uid://bc6wki4amvsx" path="res://scripts/battle.gd" id="1_a12nh"]
 [ext_resource type="Texture2D" uid="uid://b2eajagu6j5pi" path="res://assets/sprites/pokemon_rpg_screen_grayscale.png" id="1_dn72j"]
 [ext_resource type="Theme" uid="uid://bb5xdt6d0xc8h" path="res://assets/themes/main.tres" id="2_p1qf1"]
 [ext_resource type="Script" uid="uid://mb41k8rtgn0q" path="res://scripts/back_button.gd" id="4_saiin"]
 [ext_resource type="Script" uid="uid://yal21vgfjdjg" path="res://scripts/health_panel.gd" id="5_61i1y"]
-[ext_resource type="StyleBox" uid="uid://biow57dl4dwgl" path="res://assets/styles/hp_bar_background_sbf.tres" id="6_djc8l"]
-[ext_resource type="StyleBox" uid="uid://bg1kpjok5bcns" path="res://assets/styles/hp_foreground_green_sbf.tres" id="7_h4dll"]
 [ext_resource type="Script" uid="uid://brto6aw55bukl" path="res://scripts/states/Info.gd" id="7_v7i3o"]
 [ext_resource type="Script" uid="uid://buy2ylv1t0vt0" path="res://scripts/states/EnemyAttack.gd" id="8_66ngm"]
 [ext_resource type="Script" uid="uid://bl3wtt7v3rtpm" path="res://scripts/states/SelectingAction.gd" id="9_03edq"]
@@ -337,8 +335,7 @@ offset_left = 148.0
 offset_top = 70.0
 offset_right = 208.0
 offset_bottom = 78.0
-theme_override_styles/background = ExtResource("6_djc8l")
-theme_override_styles/fill = ExtResource("7_h4dll")
+theme = ExtResource("2_p1qf1")
 value = 49.0
 show_percentage = false
 
@@ -351,8 +348,7 @@ offset_left = 20.0
 offset_top = 30.0
 offset_right = 80.0
 offset_bottom = 38.0
-theme_override_styles/background = ExtResource("6_djc8l")
-theme_override_styles/fill = ExtResource("7_h4dll")
+theme = ExtResource("2_p1qf1")
 show_percentage = false
 
 [node name="EnemyHealthLabel" type="RichTextLabel" parent="HealthPanels/EnemyHealth"]

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -5,23 +5,19 @@
 [ext_resource type="Theme" uid="uid://bb5xdt6d0xc8h" path="res://assets/themes/main.tres" id="2_p1qf1"]
 [ext_resource type="Script" uid="uid://mb41k8rtgn0q" path="res://scripts/back_button.gd" id="4_saiin"]
 [ext_resource type="Script" uid="uid://yal21vgfjdjg" path="res://scripts/health_panel.gd" id="5_61i1y"]
+[ext_resource type="StyleBox" uid="uid://biow57dl4dwgl" path="res://assets/styles/hp_bar_background_sbf.tres" id="6_djc8l"]
+[ext_resource type="StyleBox" uid="uid://bg1kpjok5bcns" path="res://assets/styles/hp_foreground_green_sbf.tres" id="7_h4dll"]
 [ext_resource type="Script" uid="uid://brto6aw55bukl" path="res://scripts/states/Info.gd" id="7_v7i3o"]
 [ext_resource type="Script" uid="uid://buy2ylv1t0vt0" path="res://scripts/states/EnemyAttack.gd" id="8_66ngm"]
 [ext_resource type="Script" uid="uid://bl3wtt7v3rtpm" path="res://scripts/states/SelectingAction.gd" id="9_03edq"]
 [ext_resource type="Script" uid="uid://dxrkm475i6ls6" path="res://scripts/states/SelectingAttack.gd" id="10_22uqi"]
 [ext_resource type="Script" uid="uid://cmikjgcwtvkyk" path="res://scripts/states/IncrementTurn.gd" id="12_03edq"]
 [ext_resource type="Script" uid="uid://bm0o2eovnfws7" path="res://scripts/states/Attack.gd" id="13_6ni85"]
-[ext_resource type="Script" uid="uid://sdwupuxudrjb" path="res://scripts/states/BattleOver.gd" id="13_22uqi"]
+[ext_resource type="Script" path="res://scripts/states/BattleOver.gd" id="13_22uqi"]
 [ext_resource type="Script" uid="uid://d0rdycr2tr5ll" path="res://scripts/states/EnactStatuses.gd" id="14_6ni85"]
 [ext_resource type="Script" uid="uid://m7sdis15lg1t" path="res://scripts/states/SelectingAttackPPRestore.gd" id="17_dd63g"]
 [ext_resource type="Script" uid="uid://flenaawlfq4g" path="res://scripts/states/SelectingItem.gd" id="20_61i1y"]
 [ext_resource type="PackedScene" uid="uid://capm3p3n50hky" path="res://scenes/ui_manager.tscn" id="23_fpf3k"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ekamt"]
-bg_color = Color(0.227451, 0.266667, 0.4, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_djc8l"]
-bg_color = Color(0.243137, 0.537255, 0.282353, 1)
 
 [node name="Battle" type="Node2D"]
 script = ExtResource("1_a12nh")
@@ -341,8 +337,9 @@ offset_left = 148.0
 offset_top = 70.0
 offset_right = 208.0
 offset_bottom = 78.0
-theme_override_styles/background = SubResource("StyleBoxFlat_ekamt")
-theme_override_styles/fill = SubResource("StyleBoxFlat_djc8l")
+theme_override_styles/background = ExtResource("6_djc8l")
+theme_override_styles/fill = ExtResource("7_h4dll")
+value = 49.0
 show_percentage = false
 
 [node name="EnemyHealth" type="Node2D" parent="HealthPanels"]
@@ -354,8 +351,8 @@ offset_left = 20.0
 offset_top = 30.0
 offset_right = 80.0
 offset_bottom = 38.0
-theme_override_styles/background = SubResource("StyleBoxFlat_ekamt")
-theme_override_styles/fill = SubResource("StyleBoxFlat_djc8l")
+theme_override_styles/background = ExtResource("6_djc8l")
+theme_override_styles/fill = ExtResource("7_h4dll")
 show_percentage = false
 
 [node name="EnemyHealthLabel" type="RichTextLabel" parent="HealthPanels/EnemyHealth"]
@@ -425,3 +422,4 @@ unique_name_in_owner = true
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Attack" to="BattleStateMachine/SELECTING_ACTION" method="_on_attack_pressed"]
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Item" to="BattleStateMachine/SELECTING_ACTION" method="_on_item_pressed"]
 [connection signal="pressed" from="BottomBar/BattleStatus/ContinueButton" to="." method="_on_continue_button_pressed"]
+[connection signal="value_changed" from="HealthPanels/PlayerHealth/PlayerHPBar" to="UiManager" method="set_hp_bar_color"]

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -13,7 +13,7 @@
 [ext_resource type="Script" uid="uid://dxrkm475i6ls6" path="res://scripts/states/SelectingAttack.gd" id="10_22uqi"]
 [ext_resource type="Script" uid="uid://cmikjgcwtvkyk" path="res://scripts/states/IncrementTurn.gd" id="12_03edq"]
 [ext_resource type="Script" uid="uid://bm0o2eovnfws7" path="res://scripts/states/Attack.gd" id="13_6ni85"]
-[ext_resource type="Script" path="res://scripts/states/BattleOver.gd" id="13_22uqi"]
+[ext_resource type="Script" uid="uid://sdwupuxudrjb" path="res://scripts/states/BattleOver.gd" id="13_22uqi"]
 [ext_resource type="Script" uid="uid://d0rdycr2tr5ll" path="res://scripts/states/EnactStatuses.gd" id="14_6ni85"]
 [ext_resource type="Script" uid="uid://m7sdis15lg1t" path="res://scripts/states/SelectingAttackPPRestore.gd" id="17_dd63g"]
 [ext_resource type="Script" uid="uid://flenaawlfq4g" path="res://scripts/states/SelectingItem.gd" id="20_61i1y"]
@@ -422,4 +422,3 @@ unique_name_in_owner = true
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Attack" to="BattleStateMachine/SELECTING_ACTION" method="_on_attack_pressed"]
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Item" to="BattleStateMachine/SELECTING_ACTION" method="_on_item_pressed"]
 [connection signal="pressed" from="BottomBar/BattleStatus/ContinueButton" to="." method="_on_continue_button_pressed"]
-[connection signal="value_changed" from="HealthPanels/PlayerHealth/PlayerHPBar" to="UiManager" method="set_hp_bar_color"]

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://bpa0ix5wqg68n"]
+[gd_scene load_steps=19 format=3 uid="uid://bpa0ix5wqg68n"]
 
 [ext_resource type="Script" uid="uid://bc6wki4amvsx" path="res://scripts/battle.gd" id="1_a12nh"]
 [ext_resource type="Texture2D" uid="uid://b2eajagu6j5pi" path="res://assets/sprites/pokemon_rpg_screen_grayscale.png" id="1_dn72j"]
@@ -16,6 +16,12 @@
 [ext_resource type="Script" uid="uid://m7sdis15lg1t" path="res://scripts/states/SelectingAttackPPRestore.gd" id="17_dd63g"]
 [ext_resource type="Script" uid="uid://flenaawlfq4g" path="res://scripts/states/SelectingItem.gd" id="20_61i1y"]
 [ext_resource type="PackedScene" uid="uid://capm3p3n50hky" path="res://scenes/ui_manager.tscn" id="23_fpf3k"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ekamt"]
+bg_color = Color(0.227451, 0.266667, 0.4, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_djc8l"]
+bg_color = Color(0.243137, 0.537255, 0.282353, 1)
 
 [node name="Battle" type="Node2D"]
 script = ExtResource("1_a12nh")
@@ -309,22 +315,9 @@ autowrap_mode = 2
 [node name="HealthPanels" type="Node2D" parent="."]
 position = Vector2(-1, 0)
 
-[node name="EnemyHealthLabel" type="RichTextLabel" parent="HealthPanels"]
-unique_name_in_owner = true
-texture_filter = 1
-offset_left = 17.0
-offset_top = 16.0
-offset_right = 114.0
-offset_bottom = 41.0
-size_flags_horizontal = 3
-theme = ExtResource("2_p1qf1")
-bbcode_enabled = true
-text = "Enemy"
-fit_content = true
-scroll_active = false
-autowrap_mode = 0
+[node name="PlayerHealth" type="Node2D" parent="HealthPanels"]
 
-[node name="PlayerHealthLabel" type="RichTextLabel" parent="HealthPanels"]
+[node name="PlayerHealthLabel" type="RichTextLabel" parent="HealthPanels/PlayerHealth"]
 unique_name_in_owner = true
 texture_filter = 1
 custom_minimum_size = Vector2(96, 24)
@@ -340,6 +333,45 @@ fit_content = true
 scroll_active = false
 autowrap_mode = 0
 script = ExtResource("5_61i1y")
+
+[node name="PlayerHPBar" type="ProgressBar" parent="HealthPanels/PlayerHealth"]
+unique_name_in_owner = true
+z_index = 2
+offset_left = 148.0
+offset_top = 70.0
+offset_right = 208.0
+offset_bottom = 78.0
+theme_override_styles/background = SubResource("StyleBoxFlat_ekamt")
+theme_override_styles/fill = SubResource("StyleBoxFlat_djc8l")
+show_percentage = false
+
+[node name="EnemyHealth" type="Node2D" parent="HealthPanels"]
+
+[node name="EnemyHPBar" type="ProgressBar" parent="HealthPanels/EnemyHealth"]
+unique_name_in_owner = true
+z_index = 2
+offset_left = 20.0
+offset_top = 30.0
+offset_right = 80.0
+offset_bottom = 38.0
+theme_override_styles/background = SubResource("StyleBoxFlat_ekamt")
+theme_override_styles/fill = SubResource("StyleBoxFlat_djc8l")
+show_percentage = false
+
+[node name="EnemyHealthLabel" type="RichTextLabel" parent="HealthPanels/EnemyHealth"]
+unique_name_in_owner = true
+texture_filter = 1
+offset_left = 17.0
+offset_top = 16.0
+offset_right = 114.0
+offset_bottom = 41.0
+size_flags_horizontal = 3
+theme = ExtResource("2_p1qf1")
+bbcode_enabled = true
+text = "Enemy"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
 
 [node name="StateDisplay" type="Label" parent="."]
 unique_name_in_owner = true

--- a/scripts/monster.gd
+++ b/scripts/monster.gd
@@ -201,8 +201,7 @@ func recover_from_status_effect() -> String:
 		MovesList.StatusEffect.PARALYZE:
 			return _recover_from_paralyze()
 		MovesList.StatusEffect.CONSUME:
-			if consume_benefactor.is_alive:
-				return _recover_from_consume()
+			return _recover_from_consume()
 		MovesList.StatusEffect.BLIND:
 			return _recover_from_blind()
 	return ""
@@ -267,16 +266,21 @@ func _recover_from_paralyze():
 	return "%s recovered from paralyze" % character_name
 	
 func enact_consume_on_self():
-	var hp_to_siphen = int(max_hp * 0.04)
-	# Can only consume as much HP is missing. 
-	var max_hp_to_siphen = consume_benefactor.max_hp - consume_benefactor.hp
-	if max_hp_to_siphen == 0:
-		return "%s cannot consume because they are at full HP!" % consume_benefactor.character_name
-	elif max_hp_to_siphen < hp_to_siphen:
-		hp_to_siphen = max_hp_to_siphen
-	hp -= hp_to_siphen
-	consume_benefactor.hp += hp_to_siphen
-	return "%s consumed %s HP from %s!" % [consume_benefactor.character_name, str(hp_to_siphen), character_name]
+	if consume_benefactor.is_alive:
+		var hp_to_siphen = int(max_hp * 0.04)
+		# Can only consume as much HP is missing. 
+		var max_hp_to_siphen = consume_benefactor.max_hp - consume_benefactor.hp
+		if max_hp_to_siphen == 0:
+			return "%s cannot consume because they are at full HP!" % consume_benefactor.character_name
+		elif max_hp_to_siphen < hp_to_siphen:
+			hp_to_siphen = max_hp_to_siphen
+		hp -= hp_to_siphen
+		consume_benefactor.hp += hp_to_siphen
+		return "%s consumed %s HP from %s!" % [consume_benefactor.character_name, str(hp_to_siphen), character_name]
+	else: 
+		var message = "%s died and %s was freed from their consume!" % [consume_benefactor.character_name, character_name]
+		_recover_from_consume()
+		return message
 	
 func _recover_from_consume():
 	status_effect = MovesList.StatusEffect.NONE

--- a/scripts/monster.gd
+++ b/scripts/monster.gd
@@ -32,15 +32,11 @@ extends Resource
 	set(new_luck):
 		luck = max(1, new_luck)
 		crit_chance = crit_chance
-
 @export var crit_chance = 0.02:
-	# crit_chance caps at 30% by default
 	set(new_crit_chance):
 		crit_chance = new_crit_chance
-
 		var crit_chance_mult = float(luck) / 10
 		crit_chance = max(crit_chance, crit_chance_mult * 0.02)
-		crit_chance = min(0.3, crit_chance)
 
 var crit_factor: float = 2.0;
 

--- a/scripts/ui_manager.gd
+++ b/scripts/ui_manager.gd
@@ -46,20 +46,24 @@ func render_hp(player_monster, enemy_monster):
 		_init_references()
 
 	if enemy_monster:
-		enemy_health_panel.text = "%s %d / %d" % [enemy_monster.character_name, enemy_monster.hp, enemy_monster.max_hp]
+		enemy_health_panel.text = "%s" % enemy_monster.character_name
+		%EnemyHPBar.max_value = enemy_monster.max_hp
+		%EnemyHPBar.value = enemy_monster.hp
 	else:
 		enemy_health_panel.text = "Enemy ?"
-	player_health_panel.text = "%s %d / %d" % [player_monster.character_name, player_monster.hp, player_monster.max_hp]
+	player_health_panel.text = "%s" % player_monster.character_name
+	%PlayerHPBar.max_value = player_monster.max_hp
+	%PlayerHPBar.value = player_monster.hp
 
-	enemy_health_panel.text += "\n%s" % set_bbcode_color(MovesList.Type.find_key(enemy_monster.type), MovesList.type_to_color(enemy_monster.type))
-	player_health_panel.text += "\n%s" % set_bbcode_color(MovesList.Type.find_key(player_monster.type), MovesList.type_to_color(player_monster.type))
-
+	enemy_health_panel.text += "\t%s" % set_bbcode_color(MovesList.Type.find_key(enemy_monster.type), MovesList.type_to_color(enemy_monster.type))
+	player_health_panel.text += "\t%s" % set_bbcode_color(MovesList.Type.find_key(player_monster.type), MovesList.type_to_color(player_monster.type))
+	
 	if not enemy_monster.status_effect == MovesList.StatusEffect.NONE:
-		enemy_health_panel.text += "    %s" % set_bbcode_color(MovesList.StatusEffect.find_key(enemy_monster.status_effect), MovesList.status_effect_to_color(enemy_monster.status_effect))
+		enemy_health_panel.text += "\n\t\t\t\t\t  %s" % set_bbcode_color(type_abbreviation(enemy_monster.status_effect), MovesList.status_effect_to_color(enemy_monster.status_effect))
 
 	if not player_monster.status_effect == MovesList.StatusEffect.NONE:
-		player_health_panel.text += "     %s" % MovesList.StatusEffect.find_key(player_monster.status_effect)
-
+		player_health_panel.text += "\n\t\t\t\t\t  %s" % set_bbcode_color(type_abbreviation(player_monster.status_effect), MovesList.status_effect_to_color(player_monster.status_effect))
+	
 	call_deferred("_adjust_player_health_panel_position")
 
 func _adjust_player_health_panel_position():
@@ -67,6 +71,25 @@ func _adjust_player_health_panel_position():
 
 static func set_bbcode_color(input_string: String, color: Color):
 	return "[color=%s]%s[/color]" % [color.to_html(), input_string]
+	
+func type_abbreviation(effect) -> String:
+	match effect:
+		MovesList.StatusEffect.CRIPPLE:
+			return "CRP"
+		MovesList.StatusEffect.BURN:
+			return "BRN"
+		MovesList.StatusEffect.WHIRLPOOL:
+			return "WRL"
+		MovesList.StatusEffect.POISON:
+			return "PSN"
+		MovesList.StatusEffect.PARALYZE:
+			return "PAR"
+		MovesList.StatusEffect.CONSUME:
+			return "CSM"
+		MovesList.StatusEffect.BLIND:
+			return "BLD"
+	printerr("Failed to match type abbreviation")
+	return ""
 
 func show_info_panel(visible: bool):
 	battle_status.visible = visible

--- a/scripts/ui_manager.gd
+++ b/scripts/ui_manager.gd
@@ -5,6 +5,8 @@ extends Node
 var backdrop: Sprite2D
 var player_health_panel: RichTextLabel
 var enemy_health_panel: RichTextLabel
+var player_hp_bar: ProgressBar
+var enemy_hp_bar: ProgressBar
 var state_display: Label
 var battle_status: Label
 var continue_button: Button
@@ -24,6 +26,8 @@ func _init_references():
 	backdrop = %Backdrop
 	player_health_panel = %PlayerHealthLabel
 	enemy_health_panel = %EnemyHealthLabel
+	player_hp_bar = %PlayerHPBar
+	enemy_hp_bar = %EnemyHPBar
 	state_display = %StateDisplay
 	battle_status = %BattleStatus
 	continue_button = %ContinueButton
@@ -47,13 +51,13 @@ func render_hp(player_monster, enemy_monster):
 
 	if enemy_monster:
 		enemy_health_panel.text = "%s" % enemy_monster.character_name
-		%EnemyHPBar.max_value = enemy_monster.max_hp
-		%EnemyHPBar.value = enemy_monster.hp
+		enemy_hp_bar.max_value = enemy_monster.max_hp
+		enemy_hp_bar.value = enemy_monster.hp
 	else:
 		enemy_health_panel.text = "Enemy ?"
 	player_health_panel.text = "%s" % player_monster.character_name
-	%PlayerHPBar.max_value = player_monster.max_hp
-	%PlayerHPBar.value = player_monster.hp
+	player_hp_bar.max_value = player_monster.max_hp
+	player_hp_bar.value = player_monster.hp
 
 	enemy_health_panel.text += "\t%s" % set_bbcode_color(MovesList.Type.find_key(enemy_monster.type), MovesList.type_to_color(enemy_monster.type))
 	player_health_panel.text += "\t%s" % set_bbcode_color(MovesList.Type.find_key(player_monster.type), MovesList.type_to_color(player_monster.type))
@@ -67,7 +71,7 @@ func render_hp(player_monster, enemy_monster):
 	call_deferred("_adjust_player_health_panel_position")
 
 func set_hp_bar_color(value: float):
-	var hp_bar: ProgressBar = %PlayerHPBar
+	var hp_bar: ProgressBar = player_hp_bar
 	if value / hp_bar.max_value > 0.5:
 		hp_bar.add_theme_stylebox_override("fill", load("res://assets/styles/hp_foreground_green_sbf.tres"))
 	elif value / hp_bar.max_value > 0.25:

--- a/scripts/ui_manager.gd
+++ b/scripts/ui_manager.gd
@@ -66,6 +66,15 @@ func render_hp(player_monster, enemy_monster):
 	
 	call_deferred("_adjust_player_health_panel_position")
 
+func set_hp_bar_color(value: float):
+	var hp_bar: ProgressBar = %PlayerHPBar
+	if value / hp_bar.max_value > 0.5:
+		hp_bar.add_theme_stylebox_override("fill", load("res://assets/styles/hp_foreground_green_sbf.tres"))
+	elif value / hp_bar.max_value > 0.25:
+		hp_bar.add_theme_stylebox_override("fill", load("res://assets/styles/hp_foreground_yellow_sbf.tres"))
+	else:
+		hp_bar.add_theme_stylebox_override("fill", load("res://assets/styles/hp_foreground_red_sbf.tres"))
+
 func _adjust_player_health_panel_position():
 	player_health_panel.adjust_position()
 

--- a/scripts/ui_manager.gd
+++ b/scripts/ui_manager.gd
@@ -53,11 +53,13 @@ func render_hp(player_monster, enemy_monster):
 		enemy_health_panel.text = "%s" % enemy_monster.character_name
 		enemy_hp_bar.max_value = enemy_monster.max_hp
 		enemy_hp_bar.value = enemy_monster.hp
+		set_hp_bar_color(enemy_hp_bar)
 	else:
 		enemy_health_panel.text = "Enemy ?"
 	player_health_panel.text = "%s" % player_monster.character_name
 	player_hp_bar.max_value = player_monster.max_hp
 	player_hp_bar.value = player_monster.hp
+	set_hp_bar_color(player_hp_bar)
 
 	enemy_health_panel.text += "\t%s" % set_bbcode_color(MovesList.Type.find_key(enemy_monster.type), MovesList.type_to_color(enemy_monster.type))
 	player_health_panel.text += "\t%s" % set_bbcode_color(MovesList.Type.find_key(player_monster.type), MovesList.type_to_color(player_monster.type))
@@ -70,11 +72,10 @@ func render_hp(player_monster, enemy_monster):
 	
 	call_deferred("_adjust_player_health_panel_position")
 
-func set_hp_bar_color(value: float):
-	var hp_bar: ProgressBar = player_hp_bar
-	if value / hp_bar.max_value > 0.5:
+func set_hp_bar_color(hp_bar):
+	if hp_bar.value / hp_bar.max_value > 0.5:
 		hp_bar.add_theme_stylebox_override("fill", load("res://assets/styles/hp_foreground_green_sbf.tres"))
-	elif value / hp_bar.max_value > 0.25:
+	elif hp_bar.value / hp_bar.max_value > 0.25:
 		hp_bar.add_theme_stylebox_override("fill", load("res://assets/styles/hp_foreground_yellow_sbf.tres"))
 	else:
 		hp_bar.add_theme_stylebox_override("fill", load("res://assets/styles/hp_foreground_red_sbf.tres"))


### PR DESCRIPTION
## Summary
 - HP Sliders are set to yellow if player/enemy HP is below 50%
 - HP Sliders are set to red if player/enemy HP is below 25%

## Misc
 - Add outlines to sliders
 - Save slider styleboxes as assets (`assets/styles/...`)