### PR TITLE
Hp now counts down at a consistent rate

### DIFF
--- a/scripts/health_panel.gd
+++ b/scripts/health_panel.gd
@@ -11,20 +11,34 @@ func _ready():
 
 
 func render_hp(monster: Monster):
+	var damage = monster.prior_hp - monster.hp
 	%NameLabel.text = "%s" % monster.character_name
 	%HPBar.max_value = monster.max_hp
-	%HPBar.value = monster.hp
-	_set_hp_bar_color()
-
-	%HPNumber.text = "%d / %d" % [monster.hp, monster.max_hp]
 	%TypeLabel.text = "%s" % _set_bbcode_color(MovesList.Type.find_key(monster.type), MovesList.type_to_color(monster.type))
-
 	if not monster.status_effect == MovesList.StatusEffect.NONE:
 		%StatusLabelPanel.visible = true
 		%StatusLabel.text = "%s" % _set_bbcode_color(MovesList.type_abbreviation(monster.status_effect), MovesList.status_effect_to_color(monster.status_effect))
-
 	else:
 		%StatusLabelPanel.visible = false
+	while damage > 0 and monster.prior_hp > 0:
+		if damage >= 10:
+			monster.prior_hp -= 10
+			damage -= 10
+		else:
+			monster.prior_hp -= damage
+			damage = 0
+		%HPBar.value = monster.prior_hp
+		_set_hp_bar_color()
+		%HPNumber.text = "%d / %d" % [monster.prior_hp, monster.max_hp]
+		# Wait 4 frames
+		for i in 4:
+			await get_tree().process_frame
+
+	# Set again here, for cases in which we need to render and no damage was done.
+	%HPBar.value = monster.hp
+	_set_hp_bar_color()
+	%HPNumber.text = "%d / %d" % [monster.hp, monster.max_hp]
+	monster.prior_hp = 0
 
 
 func _set_hp_bar_color():

--- a/scripts/monster.gd
+++ b/scripts/monster.gd
@@ -49,8 +49,13 @@ var status_effect_turn_counter: int = 0
 var consume_benefactor: Monster = null
 var is_player = true
 
+# Save prior hp for hp rendering purposes
+var prior_hp = 0
+
+
 func increment_health(value: int) -> void:
 	hp += value
+
 
 func level_up(stat_multiplier: float):
 	var old_max_hp = max_hp
@@ -63,6 +68,7 @@ func level_up(stat_multiplier: float):
 	sp_def *= stat_multiplier
 	speed *= stat_multiplier
 	luck *= stat_multiplier
+
 
 func use_move(index: int, target: Monster) -> AttackResults:
 	# This is done here rather than in EnactStatuses.gd so that speed doesn't have an impact on how long status effects will last.
@@ -136,6 +142,7 @@ func _attack(move: Move, target: Monster, is_physical: bool) -> AttackResults:
 
 	var int_damage = int(damage)
 
+	target.prior_hp = target.hp
 	target.hp -= int_damage
 
 	return AttackResults.new(move, int_damage, true, false, is_critical)

--- a/scripts/states/Attack.gd
+++ b/scripts/states/Attack.gd
@@ -41,7 +41,7 @@ func _generate_attack_messages(attacker, target, results) -> Array:
 		messages.append("%s missed %s!" % [attacker.character_name, used_move_name])
 	elif damage > 0:
 		var effectiveness_multiplier: float = attacker.get_effectiveness_modifier(used_move, target)
-		var message = "%s used %s on %s for %d damage!" % [attacker.character_name, used_move_name, target.character_name, damage]
+		var message = "%s used %s on %s for %d damage!" % [attacker.character_name, used_move_name, target.character_name, min(damage, target.prior_hp)]
 		if is_critical:
 			message += " Critical Hit!"
 		messages.append(message)

--- a/scripts/states/Info.gd
+++ b/scripts/states/Info.gd
@@ -6,13 +6,16 @@ var message_index: int = 0
 
 
 func enter(_messages: Array = []):
-	battle.ui_manager.render_hp(GameManager.player.selected_monster, GameManager.enemy.selected_monster)
 	battle.ui_manager.render_battlers()
 	battle.ui_manager.show_info_panel(true)
 	battle.ui_manager.focus_continue_button()
 	messages = _messages
 	message_index = 0
 	_update_message()
+	# Block continue button while hp is being rendered.
+	GameManager.current_battle.ui_manager.continue_button.disabled = true
+	await battle.ui_manager.render_hp(GameManager.player.selected_monster, GameManager.enemy.selected_monster)
+	GameManager.current_battle.ui_manager.continue_button.disabled = false
 	if messages.size() == 0:
 		print("\tno messages; skipping INFO state")
 		handle_continue()

--- a/scripts/ui_manager.gd
+++ b/scripts/ui_manager.gd
@@ -50,8 +50,8 @@ func render_hp(player_monster, enemy_monster):
 	if !initialized:
 		_init_references()
 
-	enemy_health_panel.render_hp(enemy_monster)
-	player_health_panel.render_hp(player_monster)
+	await enemy_health_panel.render_hp(enemy_monster)
+	await player_health_panel.render_hp(player_monster)
 
 
 func render_battlers():


### PR DESCRIPTION
- Now saving "monster.prior_hp" for use in the rendering function
- HP rendering function refactored to visually remove 10 hp every 4 frames
- HP rendering is triggered in info, so that the move in question can be displayed as a message first. The continue button is disabled to disallow progressing game state until hp is done rendering. 