### PR TITLE
Adjustments and Bug Fixes

### DIFF
--- a/resources/moves/delusion.tres
+++ b/resources/moves/delusion.tres
@@ -4,14 +4,9 @@
 
 [resource]
 script = ExtResource("1_lu2fq")
-move_name = "Whirlpool"
-category = 0
-type = 0
+move_name = "Delusion"
+type = 2
 base_power = 40
-acc = 100
 pp = 1000000
 max_pp = 1000000
-status_effect = 0
-status_effect_chance = 100
-priority = false
 metadata/_custom_type_script = "uid://dj7o2vdrnopw3"

--- a/resources/moves/global_moves_list.tres
+++ b/resources/moves/global_moves_list.tres
@@ -11,7 +11,7 @@
 [ext_resource type="Resource" uid="uid://cup1blpmfdi8p" path="res://resources/moves/heat_wave.tres" id="5_uk1h8"]
 [ext_resource type="Resource" uid="uid://cj401xdexfiwj" path="res://resources/moves/fire_punch.tres" id="6_f500o"]
 [ext_resource type="Script" uid="uid://btgl7ks1m3ei3" path="res://scripts/moves_list.gd" id="7_2u8do"]
-[ext_resource type="Resource" uid="uid://8jcddcsnbyms" path="res://resources/moves/whirlpool.tres" id="7_qyrit"]
+[ext_resource type="Resource" uid="uid://8jcddcsnbyms" path="res://resources/moves/delusion.tres" id="7_qyrit"]
 [ext_resource type="Resource" uid="uid://en3lvxoqdpbg" path="res://resources/moves/electrocute.tres" id="9_xl5mf"]
 [ext_resource type="Resource" uid="uid://chacpi7ng0b4p" path="res://resources/moves/paralyzed.tres" id="10_lqm4p"]
 [ext_resource type="Resource" uid="uid://bjmuju8kjgv2l" path="res://resources/moves/vortex.tres" id="11_1l5jq"]

--- a/resources/trinkets/haymaker.tres
+++ b/resources/trinkets/haymaker.tres
@@ -1,11 +1,17 @@
-[gd_resource type="Resource" script_class="Trinket" load_steps=3 format=3 uid="uid://cwhqnhbi0ca5h"]
+[gd_resource type="Resource" script_class="Trinket" load_steps=5 format=3 uid="uid://cwhqnhbi0ca5h"]
 
 [ext_resource type="Script" uid="uid://c7ph0ydi5trjd" path="res://scripts/trinket.gd" id="1_bphy4"]
 [ext_resource type="Texture2D" uid="uid://0tu4rht0gtat" path="res://assets/sprites/trinket_icons/haymaker.png" id="1_hicn7"]
+[ext_resource type="Script" uid="uid://bdw5aqq0o851n" path="res://resources/trinket_strategies/haymaker_strategy.gd" id="3_jgb3b"]
+
+[sub_resource type="Resource" id="Resource_biws1"]
+script = ExtResource("3_jgb3b")
+metadata/_custom_type_script = "uid://bdw5aqq0o851n"
 
 [resource]
 script = ExtResource("1_bphy4")
 trinket_name = "Haymaker"
 icon = ExtResource("1_hicn7")
 description = "200% def[br]50% acc"
+strategy = SubResource("Resource_biws1")
 metadata/_custom_type_script = "uid://c7ph0ydi5trjd"

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -33,6 +33,7 @@ z_index = 1
 
 [node name="PlayerPrompt" type="Label" parent="BottomBar"]
 unique_name_in_owner = true
+visible = false
 z_index = 1
 offset_top = 95.0
 offset_right = 161.0
@@ -46,6 +47,7 @@ autowrap_mode = 2
 
 [node name="Action" type="Control" parent="BottomBar"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 3
 anchors_preset = 0
 

--- a/scripts/item.gd
+++ b/scripts/item.gd
@@ -129,10 +129,10 @@ func _handle_cripple_heal(selected_monster, battle):
 		return true  # return the item to the player
 
 
-func _handle_whirlpool_heal(selected_monster, battle):
-	if selected_monster.status_effect == MovesList.StatusEffect.WHIRLPOOL:
+func _handle_delusion_heal(selected_monster, battle):
+	if selected_monster.status_effect == MovesList.StatusEffect.DELUSION:
 		selected_monster.recover_from_status_effect()
-		battle.transition_state_to(battle.STATE_INFO, ["%s escaped the WHIRLPOOL" % selected_monster.character_name])
+		battle.transition_state_to(battle.STATE_INFO, ["%s escaped the DELUSION" % selected_monster.character_name])
 	else:
 		return true  # return the item to the player
 

--- a/scripts/monster.gd
+++ b/scripts/monster.gd
@@ -86,7 +86,7 @@ func randomize_moves() -> void:
 	var all_moves = GameManager.moves_list.moves.duplicate()
 	
 	# Remove moves that signify status conditions
-	all_moves = all_moves.filter(func(m): return m.move_name != "Paralyzed" and m.move_name != "Whirlpool")
+	all_moves = all_moves.filter(func(m): return m.move_name != "Paralyzed" and m.move_name != "Delusion")
 	all_moves.shuffle()
 	for move in all_moves.slice(0, 4):
 		moves.append(move.copy())
@@ -120,12 +120,12 @@ func use_move(index: int, target: Monster) -> AttackResults:
 	var status_applied: bool = 0
 	var damage = 0
 	var is_critical := false
-	if status_effect == MovesList.StatusEffect.WHIRLPOOL:
-		# Whirlpool has a 50% chance to damage the affected character each turn
-		var whirlpool_activation_chance = 50
-		move_hit = _does_move_hit_or_crit(whirlpool_activation_chance)
+	if status_effect == MovesList.StatusEffect.DELUSION:
+		# Delusion has a 50% chance to damage the affected character each turn
+		var delusion_activation_chance = 50
+		move_hit = _does_move_hit_or_crit(delusion_activation_chance)
 		if move_hit:
-			move = GameManager.get_move_by_name("Whirlpool")
+			move = GameManager.get_move_by_name("Delusion")
 			var results = _attack(move, self, 1)
 			return AttackResults.new(move, max(1, results["damage"]), move_hit, status_applied, results["is_critical"])
 
@@ -215,11 +215,11 @@ func _check_status_immunity(effect: MovesList.StatusEffect, target_type: MovesLi
 		MovesList.StatusEffect.BURN:
 			if target_type == MovesList.Type.FIRE:
 				return true
-		MovesList.StatusEffect.WHIRLPOOL:
-			if target_type == MovesList.Type.WATER:
+		MovesList.StatusEffect.DELUSION:
+			if target_type == MovesList.Type.SPIRIT:
 				return true
 		MovesList.StatusEffect.POISON:
-			if target_type == MovesList.Type.PLANT:
+			if target_type == MovesList.Type.POISON:
 				return true
 		MovesList.StatusEffect.PARALYZE:
 			if target_type == MovesList.Type.PLASMA:
@@ -265,8 +265,8 @@ func recover_from_status_effect() -> String:
 			return _recover_from_cripple()
 		MovesList.StatusEffect.BURN:
 			return _recover_from_burn()
-		MovesList.StatusEffect.WHIRLPOOL:
-			return _recover_from_whirlpool()
+		MovesList.StatusEffect.DELUSION:
+			return _recover_from_delusion()
 		MovesList.StatusEffect.POISON:
 			return _recover_from_poison()
 		MovesList.StatusEffect.PARALYZE:
@@ -320,10 +320,10 @@ func _recover_from_burn():
 	return "%s recovered from burn!" % character_name
 
 
-func _recover_from_whirlpool():
+func _recover_from_delusion():
 	status_effect = MovesList.StatusEffect.NONE
 	status_effect_turn_counter = 0
-	return "%s recovered from whirlpool!" % character_name
+	return "%s recovered from delusion!" % character_name
 
 
 func enact_poison_on_self():

--- a/scripts/moves_list.gd
+++ b/scripts/moves_list.gd
@@ -3,16 +3,16 @@ class_name MovesList
 
 @export var moves: Array[Move]
 
-enum Type {HUMAN, FIRE, WATER, PLANT, PLASMA, DARK, LIGHT}
-				  		# HUMAN, FIRE,  WATER,   PLANT,   PLASMA,   DARK,   LIGHT
-enum StatusEffect {NONE, CRIPPLE, BURN, WHIRLPOOL, POISON, PARALYZE, CONSUME, BLIND}
+enum Type {HUMAN, FIRE, SPIRIT, POISON, PLASMA, DARK, LIGHT}
+				  		# HUMAN, FIRE,  SPIRIT,   POISON,   PLASMA,   DARK,   LIGHT
+enum StatusEffect {NONE, CRIPPLE, BURN, DELUSION, POISON, PARALYZE, CONSUME, BLIND}
 
 
 const TYPES = {
 	Type.HUMAN: 0,
 	Type.FIRE: 1,
-	Type.WATER: 2,
-	Type.PLANT: 3,
+	Type.SPIRIT: 2,
+	Type.POISON: 3,
 	Type.PLASMA: 4,
 	Type.DARK: 5,
 	Type.LIGHT: 6
@@ -20,11 +20,11 @@ const TYPES = {
 
 # Row = Attacker, Col = Defender
 const TYPE_CHART = [
-# HUMAN FIRE  WATER PLANT Earth DARK  LIGHT
+# HUMAN FIRE  SPIRIT POISON Earth DARK  LIGHT
 [ 1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0 ], # HUMAN
 [ 1.0,  1.0,  0.5,  2.0,  1.0,  0.5,  2.0 ], # FIRE
-[ 1.0,  2.0,  1.0,  0.5,  2.0,  1.0,  0.5 ], # WATER
-[ 1.0,  0.5,  2.0,  1.0,  2.0,  0.5,  1.0 ], # PLANT
+[ 1.0,  2.0,  1.0,  0.5,  2.0,  1.0,  0.5 ], # SPIRIT
+[ 1.0,  0.5,  2.0,  1.0,  2.0,  0.5,  1.0 ], # POISON
 [ 1.0,  1.0,  0.5,  0.5,  1.0,  2.0,  2.0 ], # PLASMA
 [ 1.0,  2.0,  1.0,  2.0,  0.5,  1.0,  0.5 ], # DARK
 [ 1.0,  0.5,  2.0,  1.0,  0.5,  2.0,  1.0 ]  # LIGHT
@@ -37,9 +37,9 @@ static func type_to_color(type: Type) -> Color:
 			return Color(0.996, 0.906, 0.38, 1.0)
 		Type.FIRE:
 			return Color(0.894, 0.231, 0.267, 1.0)
-		Type.WATER:
+		Type.SPIRIT:
 			return Color(0.0, 0.6, 0.859, 1.0)
-		Type.PLANT:
+		Type.POISON:
 			return Color(0.388, 0.78, 0.302, 1.0)
 		Type.PLASMA:
 			return Color(0.71, 0.314, 0.533, 1.0)
@@ -56,7 +56,7 @@ static func status_effect_to_color(status_effect: StatusEffect) -> Color:
 			return Color(0.996, 0.906, 0.38, 1.0)
 		MovesList.StatusEffect.BURN:
 			return Color(0.894, 0.231, 0.267, 1.0)
-		MovesList.StatusEffect.WHIRLPOOL:
+		MovesList.StatusEffect.DELUSION:
 			return Color(0.0, 0.6, 0.859, 1.0)
 		MovesList.StatusEffect.POISON:
 			return Color(0.388, 0.78, 0.302, 1.0)
@@ -75,8 +75,8 @@ static func type_abbreviation(effect) -> String:
 			return "CRP"
 		MovesList.StatusEffect.BURN:
 			return "BRN"
-		MovesList.StatusEffect.WHIRLPOOL:
-			return "WRL"
+		MovesList.StatusEffect.DELUSION:
+			return "DEL"
 		MovesList.StatusEffect.POISON:
 			return "PSN"
 		MovesList.StatusEffect.PARALYZE:

--- a/scripts/states/Attack.gd
+++ b/scripts/states/Attack.gd
@@ -32,8 +32,8 @@ func _generate_attack_messages(attacker, target, results) -> Array:
 	var damage = results.damage
 	var move_hit = results.move_hit
 	var is_critical = results.is_critical
-	if used_move_name == "Whirlpool":
-		messages.append("%s got caught in the whirlpool!" % [attacker.character_name])
+	if used_move_name == "Delusion":
+		messages.append("%s got caught in the delusion!" % [attacker.character_name])
 		return messages
 	elif used_move_name == "Paralyzed":
 		messages.append("%s is paralyzed and could not move!" % attacker.character_name)

--- a/scripts/states/Attack.gd
+++ b/scripts/states/Attack.gd
@@ -85,12 +85,14 @@ func _generate_attack_messages(attacker, target, results) -> Array:
 			messages.append("%s used %s and applied %s on %s!" % [attacker.character_name, used_move_name, status_effect_string, target.character_name])
 		else:
 			messages.append("%s was afflicted with %s!" % [target.character_name, status_effect_string])
-		# Burn and cripple need to be applied instantly since they affect the stats of the afflicted user.
+		# Burn, cripple, and paralyze need to be applied instantly since they affect the stats of the afflicted user.
 		match status_effect:
 			MovesList.StatusEffect.CRIPPLE:
 				messages.append(target.enact_cripple_on_self())
 			MovesList.StatusEffect.BURN:
 				messages.append(target.enact_burn_on_self())
+			MovesList.StatusEffect.PARALYZE:
+				messages.append(target.enact_paralyze_on_self())
 			MovesList.StatusEffect.BLIND:
 				messages.append("%s's accuracy was lowered by 33" % target.character_name + "%!")
 	return messages

--- a/scripts/status_emitter.gd
+++ b/scripts/status_emitter.gd
@@ -14,7 +14,7 @@ func _render_status():
 	var shader_material: ShaderMaterial = material
 	position = Vector2(0, 0)
 	match status_effect:
-		MovesList.StatusEffect.WHIRLPOOL:
+		MovesList.StatusEffect.DELUSION:
 			emitting = true
 			gravity = Vector2(0, 250)
 			position.y -= 8


### PR DESCRIPTION
Bug fixes: 
- Turn 1 text boxes if enemy is faster
- does_move_hit_or_crit no longer checks for BLIND or monster acc if checking for status effect hit or crit, because the move already hit
       - If you prefer, I can refactor this into 2 seperate functions for checking if the move hit, and a seperate function checking if the status hit or if it's a critical hit. 
- Added strategy script to haymaker trinket
- TODO: Fix bug where "X was statused!" appears even if the opposing Monster is already dead
- TODO: Fix Plant immune to CRIPPLE bug, if the other changes don't fix it for me.

TODO: Set up a testing tool that allows the player to select the moves of the player/enemies (I'll likely do this on a seperate branch and merge it in here)
TODO: Apply the BLIND status effect directly to monster.acc