### PR TITLE
Get Trinket Menu Functioning

### DIFF
--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -383,6 +383,7 @@ script = ExtResource("20_61i1y")
 unique_name_in_owner = true
 
 [node name="TrinketShelf" parent="." node_paths=PackedStringArray("trinket_info_label", "trinket_info_panel", "trinket_info_sprite") instance=ExtResource("17_h4dll")]
+unique_name_in_owner = true
 trinket_info_label = NodePath("../TrinketInfoLabel")
 trinket_info_panel = NodePath("../TrinketInfoSpritePanel")
 trinket_info_sprite = NodePath("../TrinketInfoSpritePanel/TrinketInfoSprite")

--- a/scenes/debug_menu.tscn
+++ b/scenes/debug_menu.tscn
@@ -77,7 +77,7 @@ layout_mode = 2
 theme = ExtResource("2_03so6")
 theme_type_variation = &"BorderButton"
 action_mode = 0
-text = "Give Player Trinket (debug) (WIP)"
+text = "Give Player Trinket (debug)"
 alignment = 2
 
 [node name="TrinketsList" type="Tree" parent="PanelContainer/VBoxContainer"]

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -47,7 +47,10 @@ func setup(_player: BattleParticipant, _enemy: BattleParticipant):
 	print("Assigned player:", _player.name, _player.selected_monster.character_name)
 	print("Assigned enemy:", enemy.name, enemy.selected_monster.character_name)
 
-	player.trinkets_updated.connect(func(): %TrinketShelf.render_trinkets())
+	player.trinkets_updated.connect(func():
+		%TrinketShelf.render_trinkets()
+		update_active_monsters()
+	)
 
 
 func update_active_monsters():

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -47,6 +47,7 @@ func setup(_player: BattleParticipant, _enemy: BattleParticipant):
 	print("Assigned player:", _player.name, _player.selected_monster.character_name)
 	print("Assigned enemy:", enemy.name, enemy.selected_monster.character_name)
 
+	player.trinkets_updated.connect(func(): %TrinketShelf.render_trinkets())
 
 func update_active_monsters():
 	active_monsters = [player.selected_monster, enemy.selected_monster]

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -49,6 +49,7 @@ func setup(_player: BattleParticipant, _enemy: BattleParticipant):
 
 	player.trinkets_updated.connect(func(): %TrinketShelf.render_trinkets())
 
+
 func update_active_monsters():
 	active_monsters = [player.selected_monster, enemy.selected_monster]
 	active_monsters.sort_custom(_sort_participants_by_speed)

--- a/scripts/battle_participant.gd
+++ b/scripts/battle_participant.gd
@@ -21,12 +21,6 @@ func emit_trinkets_updated_signal():
 	trinkets_updated.emit()
 
 
-# called at the start of battle -- applies trinket effects to the player's monster
-func apply_trinkets():
-	for trinket in trinkets:
-		trinket.strategy.ApplyEffect(selected_monster)
-
-
 func setup_player(_monster: Monster):
 	monsters = [_monster]
 	position.x = 64

--- a/scripts/battle_participant.gd
+++ b/scripts/battle_participant.gd
@@ -12,7 +12,13 @@ class_name BattleParticipant
 		if monsters.size() > 0:
 			selected_monster = monsters[0]
 
+signal trinkets_updated
+
 var trinkets: Array[Trinket] = []
+
+
+func emit_trinkets_updated_signal():
+	trinkets_updated.emit()
 
 
 # called at the start of battle -- applies trinket effects to the player's monster

--- a/scripts/debug_menu.gd
+++ b/scripts/debug_menu.gd
@@ -61,6 +61,8 @@ func _render_trinkets_list():
 		trinketItem.set_text(0, trinket.trinket_name)
 		trinketItem.set_text(1, trinket.description)
 
+	%TrinketsList.item_selected.connect(func(): _on_debug_trinket_pressed())
+
 
 func _sort_trinkets_alphabetically(a: Trinket, b: Trinket) -> bool:
 	if a.trinket_name < b.trinket_name:
@@ -84,6 +86,11 @@ func _on_debug_move_pressed():
 		GameManager.current_battle.transition_state_to(GameManager.current_battle.STATE_ATTACK, [attackCommand])
 		toggle_pause()
 
+func _on_debug_trinket_pressed():
+	var trinket_index: int = %TrinketsList.get_selected().get_index()
+	var trinket: Trinket = _alphabetized_trinkets_list[trinket_index]
+	GameManager.player.trinkets.append(trinket)
+	GameManager.player.emit_trinkets_updated_signal()
 
 func _on_use_move_button_pressed() -> void:
 	%MovesList.visible = !%MovesList.visible

--- a/scripts/debug_menu.gd
+++ b/scripts/debug_menu.gd
@@ -3,6 +3,7 @@ extends Control
 var _alphabetized_moves_list: Array[Move]
 var _alphabetized_trinkets_list: Array[Trinket]
 
+
 func _ready() -> void:
 	if !get_parent().PROCESS_MODE_PAUSABLE:
 		push_warning("warning: parent is not pausable")
@@ -16,14 +17,17 @@ func _ready() -> void:
 	_render_moves_list()
 	_render_trinkets_list()
 
+
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_pause"):
 		toggle_pause()
+
 
 func toggle_pause():
 	var paused := not get_tree().paused
 	get_tree().paused = paused
 	visible = paused
+
 
 func _render_moves_list():
 	%MovesList.create_item()
@@ -47,6 +51,7 @@ func _render_moves_list():
 
 	%MovesList.item_selected.connect(func(): _on_debug_move_pressed())
 
+
 func _render_trinkets_list():
 	%TrinketsList.create_item()
 	%TrinketsList.set_column_title(0, "name")
@@ -69,10 +74,12 @@ func _sort_trinkets_alphabetically(a: Trinket, b: Trinket) -> bool:
 		return true
 	return false
 
+
 func _sort_moves_alphabetically(a: Move, b: Move) -> bool:
 	if a.move_name < b.move_name:
 		return true
 	return false
+
 
 func _on_debug_move_pressed():
 	var move_index: int = %MovesList.get_selected().get_index()
@@ -83,14 +90,18 @@ func _on_debug_move_pressed():
 		attackCommand.attacker = GameManager.player.selected_monster
 		attackCommand.move = move
 		attackCommand.target = GameManager.enemy.selected_monster
-		GameManager.current_battle.transition_state_to(GameManager.current_battle.STATE_ATTACK, [attackCommand])
+		GameManager.current_battle.transition_state_to(
+			GameManager.current_battle.STATE_ATTACK, [attackCommand]
+		)
 		toggle_pause()
+
 
 func _on_debug_trinket_pressed():
 	var trinket_index: int = %TrinketsList.get_selected().get_index()
 	var trinket: Trinket = _alphabetized_trinkets_list[trinket_index]
 	GameManager.player.trinkets.append(trinket)
 	GameManager.player.emit_trinkets_updated_signal()
+
 
 func _on_use_move_button_pressed() -> void:
 	%MovesList.visible = !%MovesList.visible

--- a/scripts/debug_menu.gd
+++ b/scripts/debug_menu.gd
@@ -100,6 +100,7 @@ func _on_debug_trinket_pressed():
 	var trinket_index: int = %TrinketsList.get_selected().get_index()
 	var trinket: Trinket = _alphabetized_trinkets_list[trinket_index]
 	GameManager.player.trinkets.append(trinket)
+	trinket.strategy.ApplyEffect(GameManager.player.selected_monster)
 	GameManager.player.emit_trinkets_updated_signal()
 
 

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -30,14 +30,8 @@ func start_game():
 	_load_and_randomize_monsters()
 	player = _create_player()
 	enemy = _create_new_enemy()
-	_init_player_trinkets()
 	_generate_floor_events()
 	_start_next_event()
-
-
-func _init_player_trinkets():
-	player.trinkets = trinkets_list.trinkets
-	player.apply_trinkets()
 
 
 func _load_and_randomize_monsters():

--- a/scripts/trinket_shelf.gd
+++ b/scripts/trinket_shelf.gd
@@ -17,7 +17,7 @@ func _ready():
 	if trinkets.size() == 0 && GameManager.player != null:
 		trinkets = GameManager.player.trinkets
 
-	for i in range(trinkets.size()):
+	for i in range(%TrinketIconContainer.get_child_count()):
 		var trinket_button: Button = %TrinketIconContainer.get_child(i)
 		trinket_button.mouse_entered.connect(func(): steal_focus(i))
 		trinket_button.mouse_exited.connect(return_focus)
@@ -33,6 +33,9 @@ func render_trinkets():
 		trinket_button.icon = trinket.icon
 
 func _display_trinket_info(index: int):
+	if index >= trinkets.size():
+		return
+
 	trinket_info_panel.visible = true
 	trinket_info_label.visible = true
 

--- a/scripts/trinket_shelf.gd
+++ b/scripts/trinket_shelf.gd
@@ -26,11 +26,13 @@ func _ready():
 
 	render_trinkets()
 
+
 func render_trinkets():
 	for i in range(trinkets.size()):
 		var trinket: Trinket = trinkets[i]
 		var trinket_button: Button = %TrinketIconContainer.get_child(i)
 		trinket_button.icon = trinket.icon
+
 
 func _display_trinket_info(index: int):
 	if index >= trinkets.size():

--- a/scripts/trinket_shelf.gd
+++ b/scripts/trinket_shelf.gd
@@ -18,14 +18,19 @@ func _ready():
 		trinkets = GameManager.player.trinkets
 
 	for i in range(trinkets.size()):
-		var trinket: Trinket = trinkets[i]
 		var trinket_button: Button = %TrinketIconContainer.get_child(i)
-		trinket_button.icon = trinket.icon
 		trinket_button.mouse_entered.connect(func(): steal_focus(i))
 		trinket_button.mouse_exited.connect(return_focus)
 		trinket_button.focus_entered.connect(func(): _display_trinket_info(i))
 		trinket_button.focus_exited.connect(_hide_trinket_info)
 
+	render_trinkets()
+
+func render_trinkets():
+	for i in range(trinkets.size()):
+		var trinket: Trinket = trinkets[i]
+		var trinket_button: Button = %TrinketIconContainer.get_child(i)
+		trinket_button.icon = trinket.icon
 
 func _display_trinket_info(index: int):
 	trinket_info_panel.visible = true


### PR DESCRIPTION
## Description

 - The player now starts battle with 0 trinkets
 - When a trinket is clicked in the Debug menu list, it's effect is directly applied to the player's `selected_monster`
 - When a trinket is clicked in the Debug menu list, the `trinkets_updated` signal is emitted
   - The mechanics of this are a little awkward -- the debug menu calls `GameManager.player. emit_trinkets_updated_signal ()`
   - In `battle.gd`, the player's `trinkets_updated` signals is connected to a method to re-render the trinkets shelf

## Demo (updated)

[Screen Recording 2025-07-14 at 8.31.29 PM.webm](https://github.com/user-attachments/assets/1f7b25df-7729-4c60-9c94-89a6ee82a1f0)
