### PR TITLE
Fix: Player heals to full after battle if they have an HP Up trinket

### DIFF
--- a/scripts/debug_menu.gd
+++ b/scripts/debug_menu.gd
@@ -112,7 +112,7 @@ func _on_debug_move_pressed():
 func _on_debug_trinket_pressed():
 	var trinket_index: int = %TrinketsList.get_selected().get_index()
 	var trinket: Trinket = _alphabetized_trinkets_list[trinket_index]
-	GameManager.player.trinkets.append(trinket)
+	GameManager.player.selected_monster.trinkets.append(trinket)
 	trinket.strategy.ApplyEffect(GameManager.player.selected_monster)
 	GameManager.player.selected_monster.emit_trinkets_updated_signal()
 

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -62,8 +62,8 @@ func _load_and_randomize_monsters():
 
 # generate all events for a floor.
 func _generate_floor_events():
-	#var shop = shop_scene.instantiate()
-	#floor_events.push_back(shop)
+	var shop = shop_scene.instantiate()
+	floor_events.push_back(shop)
 
 	var battle = battle_scene.instantiate()
 	floor_events.push_back(battle)
@@ -149,19 +149,11 @@ func _create_player() -> BattleParticipant:
 	new_player.selected_monster_backup = new_player.selected_monster.duplicate(true)
 	%TrinketShelf.trinkets = new_player.selected_monster.trinkets
 
-	# debug
-	new_player.selected_monster.hp -= 20
-
-	for trinket in trinkets_list.trinkets:
-		print(trinket.trinket_name)
-
-	new_player.selected_monster.trinkets.append(trinkets_list.trinkets[3])
-
 	return new_player
 
 
 func _create_new_enemy() -> BattleParticipant:
-	var monsters: Array[Monster] = [randomized_monsters[0]]
+	var monsters = randomized_monsters
 	var new_enemy = battle_participant_scene.instantiate()
 	new_enemy.set_script(preload("res://scripts/enemy.gd"))
 	# 2nd param = AI types 0 = RANDOM, 1 = AGGRESSIVE, 2 = HIGH_EV
@@ -176,10 +168,6 @@ func _create_new_enemy() -> BattleParticipant:
 
 	self.add_child(new_enemy)
 	new_enemy.name = "Enemy"
-
-	# debug
-	new_enemy.selected_monster.hp = 0
-
 	return new_enemy
 
 

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -62,8 +62,8 @@ func _load_and_randomize_monsters():
 
 # generate all events for a floor.
 func _generate_floor_events():
-	var shop = shop_scene.instantiate()
-	floor_events.push_back(shop)
+	#var shop = shop_scene.instantiate()
+	#floor_events.push_back(shop)
 
 	var battle = battle_scene.instantiate()
 	floor_events.push_back(battle)
@@ -149,11 +149,19 @@ func _create_player() -> BattleParticipant:
 	new_player.selected_monster_backup = new_player.selected_monster.duplicate(true)
 	%TrinketShelf.trinkets = new_player.selected_monster.trinkets
 
+	# debug
+	new_player.selected_monster.hp -= 20
+
+	for trinket in trinkets_list.trinkets:
+		print(trinket.trinket_name)
+
+	new_player.selected_monster.trinkets.append(trinkets_list.trinkets[3])
+
 	return new_player
 
 
 func _create_new_enemy() -> BattleParticipant:
-	var monsters = randomized_monsters
+	var monsters: Array[Monster] = [randomized_monsters[0]]
 	var new_enemy = battle_participant_scene.instantiate()
 	new_enemy.set_script(preload("res://scripts/enemy.gd"))
 	# 2nd param = AI types 0 = RANDOM, 1 = AGGRESSIVE, 2 = HIGH_EV
@@ -168,6 +176,10 @@ func _create_new_enemy() -> BattleParticipant:
 
 	self.add_child(new_enemy)
 	new_enemy.name = "Enemy"
+
+	# debug
+	new_enemy.selected_monster.hp = 0
+
 	return new_enemy
 
 

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -181,15 +181,22 @@ func level_up_player_and_enemies():
 
 func apply_trinkets():
 	var old_hp = player.selected_monster.hp
-	var monster_trinkets = player.selected_monster.trinkets
+	var old_trinkets = player.selected_monster.trinkets
+
+	var hp_bonus = 0
+	for trinket in old_trinkets:
+		if trinket.trinket_name == "HP Up":
+			hp_bonus += 100
+
 	player.selected_monster = player.selected_monster_backup.duplicate(true)
-	if old_hp > player.selected_monster.max_hp:
-		player.selected_monster.hp = player.selected_monster.max_hp
-	else:
-		player.selected_monster.hp = old_hp
-	player.selected_monster.trinkets = monster_trinkets
+
+	var max_possible_hp = min(old_hp - hp_bonus, player.selected_monster.max_hp)
+	player.selected_monster.hp = max_possible_hp
+
+	player.selected_monster.trinkets = old_trinkets
 	for trinket in player.selected_monster.trinkets:
 		trinket.strategy.ApplyEffect(player.selected_monster)
+
 	player.selected_monster.emit_trinkets_updated_signal()
 	%TrinketShelf.render_trinkets()
 


### PR DESCRIPTION
# Details
 - When applying trinkets, we assume that the player's Max HP is the same as the duplicate/"base" monster the trinkets are applied to
 - When the player has HP Up trinkets this is not the case. this results in us incorrectly assuming that players with HP Up trinkets have full health in some cases where that is not true
 - This PR changes `apply_trinkets()` to take HP Up trinkets into account