### PR TITLE
Shorten Battle UI

### DIFF
--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -36,7 +36,7 @@ z_index = 1
 unique_name_in_owner = true
 visible = false
 z_index = 1
-offset_top = 95.0
+offset_top = 111.0
 offset_right = 162.0
 offset_bottom = 143.0
 mouse_filter = 1
@@ -55,7 +55,7 @@ anchors_preset = 0
 [node name="Panel" type="Panel" parent="BottomBar/Action"]
 layout_mode = 0
 offset_left = 161.0
-offset_top = 95.0
+offset_top = 111.0
 offset_right = 256.0
 offset_bottom = 144.0
 theme = ExtResource("2_p1qf1")
@@ -66,9 +66,9 @@ unique_name_in_owner = true
 z_index = 2
 layout_mode = 0
 offset_left = 162.0
-offset_top = 96.0
+offset_top = 112.0
 offset_right = 255.0
-offset_bottom = 144.0
+offset_bottom = 143.0
 theme = ExtResource("2_p1qf1")
 
 [node name="Attack" type="Button" parent="BottomBar/Action/ActionButtons"]
@@ -92,7 +92,7 @@ alignment = 0
 [node name="BattleStatus" type="Label" parent="BottomBar"]
 unique_name_in_owner = true
 visible = false
-offset_top = 95.0
+offset_top = 111.0
 offset_right = 256.0
 offset_bottom = 143.0
 mouse_filter = 1
@@ -105,7 +105,7 @@ unique_name_in_owner = true
 z_index = -1
 layout_mode = 0
 offset_right = 255.0
-offset_bottom = 48.0
+offset_bottom = 32.0
 theme = ExtResource("2_p1qf1")
 text = "Continue"
 
@@ -118,9 +118,9 @@ anchors_preset = 0
 [node name="BackButton" type="Button" parent="BottomBar/Moves"]
 custom_minimum_size = Vector2(0, 5)
 layout_mode = 0
-offset_top = 80.0
+offset_top = 95.0
 offset_right = 32.0
-offset_bottom = 96.0
+offset_bottom = 112.0
 focus_neighbor_bottom = NodePath("../MovesMenu/Move1")
 theme = ExtResource("2_p1qf1")
 theme_type_variation = &"BorderButton"
@@ -129,7 +129,7 @@ script = ExtResource("4_saiin")
 
 [node name="Panel" type="Panel" parent="BottomBar/Moves"]
 layout_mode = 0
-offset_top = 95.0
+offset_top = 111.0
 offset_right = 162.0
 offset_bottom = 144.0
 theme = ExtResource("2_p1qf1")
@@ -139,7 +139,7 @@ theme_type_variation = &"FullBorderPanel"
 unique_name_in_owner = true
 layout_mode = 0
 offset_left = 1.0
-offset_top = 96.0
+offset_top = 112.0
 offset_right = 162.0
 offset_bottom = 144.0
 theme = ExtResource("2_p1qf1")
@@ -154,7 +154,7 @@ text = "   Move 1"
 alignment = 0
 
 [node name="Move2" type="Button" parent="BottomBar/Moves/MovesMenu"]
-custom_minimum_size = Vector2(77, 23)
+custom_minimum_size = Vector2(77, 15)
 layout_mode = 2
 theme = ExtResource("2_p1qf1")
 text = "   Move 2"
@@ -166,7 +166,7 @@ text = "   Move 3"
 alignment = 0
 
 [node name="Move4" type="Button" parent="BottomBar/Moves/MovesMenu"]
-custom_minimum_size = Vector2(80, 23)
+custom_minimum_size = Vector2(80, 15)
 layout_mode = 2
 text = "   Move 4
 "
@@ -176,7 +176,7 @@ alignment = 0
 custom_minimum_size = Vector2(0, 23)
 layout_mode = 0
 offset_left = 161.0
-offset_top = 95.0
+offset_top = 111.0
 offset_right = 256.0
 offset_bottom = 143.0
 theme = ExtResource("2_p1qf1")
@@ -184,8 +184,9 @@ theme = ExtResource("2_p1qf1")
 [node name="PPInfo" type="Label" parent="BottomBar/Moves/MoveInfo"]
 unique_name_in_owner = true
 layout_mode = 0
+offset_top = 1.0
 offset_right = 95.0
-offset_bottom = 24.0
+offset_bottom = 16.0
 theme = ExtResource("2_p1qf1")
 theme_type_variation = &"NoBorderLabel"
 text = "PP: 0/15"
@@ -195,9 +196,9 @@ vertical_alignment = 1
 [node name="TypeInfo" type="Label" parent="BottomBar/Moves/MoveInfo"]
 unique_name_in_owner = true
 layout_mode = 0
-offset_top = 23.0
+offset_top = 17.0
 offset_right = 95.0
-offset_bottom = 47.0
+offset_bottom = 32.0
 theme = ExtResource("2_p1qf1")
 theme_type_variation = &"NoBorderLabel"
 text = "TYPE: HUMAN"
@@ -212,9 +213,9 @@ anchors_preset = 0
 
 [node name="BackButton" type="Button" parent="BottomBar/Items"]
 layout_mode = 0
-offset_top = 80.0
+offset_top = 95.0
 offset_right = 32.0
-offset_bottom = 96.0
+offset_bottom = 112.0
 focus_neighbor_bottom = NodePath("../MarginContainer/ScrollContainer/ItemsMenu/Item1")
 theme = ExtResource("2_p1qf1")
 theme_type_variation = &"BorderButton"
@@ -223,7 +224,7 @@ script = ExtResource("4_saiin")
 
 [node name="Panel" type="Panel" parent="BottomBar/Items"]
 layout_mode = 0
-offset_top = 95.0
+offset_top = 111.0
 offset_right = 168.0
 offset_bottom = 144.0
 theme = ExtResource("2_p1qf1")
@@ -232,7 +233,7 @@ theme_type_variation = &"FullBorderPanel"
 [node name="MarginContainer" type="MarginContainer" parent="BottomBar/Items"]
 layout_mode = 0
 offset_left = 1.0
-offset_top = 95.0
+offset_top = 111.0
 offset_right = 170.0
 offset_bottom = 144.0
 theme = ExtResource("2_p1qf1")
@@ -290,7 +291,7 @@ alignment = 0
 custom_minimum_size = Vector2(0, 24)
 layout_mode = 0
 offset_left = 168.0
-offset_top = 95.0
+offset_top = 111.0
 offset_right = 256.0
 offset_bottom = 143.0
 theme = ExtResource("2_p1qf1")
@@ -322,9 +323,9 @@ position = Vector2(-1, 0)
 [node name="PlayerHealthPanel" parent="HealthPanels" instance=ExtResource("5_ekamt")]
 unique_name_in_owner = true
 offset_left = 145.0
-offset_top = 55.0
+offset_top = 71.0
 offset_right = 145.0
-offset_bottom = 55.0
+offset_bottom = 71.0
 
 [node name="EnemyHealthPanel" parent="HealthPanels" instance=ExtResource("5_ekamt")]
 unique_name_in_owner = true


### PR DESCRIPTION
# Summary
 - Shorten UI elements in Battle scene from 3 rows of text to 2 rows of text

# Demo
[Screencast from 2025-07-31 14-02-54.webm](https://github.com/user-attachments/assets/c1dde442-4d21-45e6-b3a5-2960001ff5a1)

# Details

 - We're going to remove Consumable Items, but I wanted to keep this PR simple so I didn't do that here.
   - Because items are still around in this PR, I shortened the Items sub-menu along with everything else