### PR TITLE
Restore original monster's moves after applying trinkets (#81)

### DIFF
--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -181,6 +181,10 @@ func level_up_player_and_enemies():
 	var monster_moves = player.selected_monster.moves
 	apply_trinkets()
 	player.selected_monster.hp = monster_hp
+
+	# The way we copy moves assumes that trinkets which modify the player's
+	# moves (e.g. PP up) do not have effects that need to be applied every time
+	# the player levels up
 	player.selected_monster.moves = monster_moves
 
 

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -178,8 +178,10 @@ func level_up_player_and_enemies():
 	player.selected_monster_backup.level_up(player_stat_multiplier)
 	# The HP gets reset to what the monster's hp was at the end of battle, plus the level up bonus
 	var monster_hp = player.selected_monster.hp + (player.selected_monster_backup.max_hp - old_max_hp)
+	var monster_moves = player.selected_monster.moves
 	apply_trinkets()
 	player.selected_monster.hp = monster_hp
+	player.selected_monster.moves = monster_moves
 
 
 func apply_trinkets():


### PR DESCRIPTION
# Description
 - Restore original monster's moves after applying trinkets
 - This means the monster's moves are not restored to full PP after every battle
 - I am assuming that trinkets which modify the player's moves (e.g. PP up) do not have effects that need to be applied every time the player levels up