### PR TITLE
Triple Monster starting HP

### DIFF
--- a/scripts/monster.gd
+++ b/scripts/monster.gd
@@ -91,8 +91,8 @@ func randomize_stat_spread(bst: int = 300, min_stat: int = 10) -> void:
 		stat_values[stat] += 1
 		remaining -= 1
 
-	max_hp = stat_values["max_hp"]
-	hp = max_hp
+	max_hp = 3 * stat_values["max_hp"]
+	hp = 3 * max_hp
 	atk = stat_values["atk"]
 	sp_atk = stat_values["sp_atk"]
 	def = stat_values["def"]


### PR DESCRIPTION
# Description
 - Triple Monster starting HP
 - this means that Monster starting HP is typically around 100-120
 - associated with issue #93

# Details 
 - I didn't end up changing the HP up trinket -- I think that increasing staring HP actually makes the HP up trinket more balanced