### PR TITLE
`health_panel.tscn`: prevent text from wrapping in HP Label (UI Fix)

### DIFF
--- a/scenes/health_panel.tscn
+++ b/scenes/health_panel.tscn
@@ -61,7 +61,7 @@ unique_name_in_owner = true
 z_index = 1
 z_as_relative = false
 layout_mode = 1
-anchors_preset = 1
+anchors_preset = -1
 anchor_left = 1.0
 anchor_right = 1.0
 offset_left = 107.0
@@ -154,7 +154,7 @@ show_percentage = false
 
 [node name="InvisiblePlaceholder" type="Panel" parent="LabelContainer"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(23, 15)
+custom_minimum_size = Vector2(1, 15)
 layout_mode = 2
 theme = ExtResource("1_5pall")
 theme_type_variation = &"EmptyPanel"
@@ -162,12 +162,16 @@ theme_type_variation = &"EmptyPanel"
 [node name="HPNumber" type="RichTextLabel" parent="LabelContainer"]
 unique_name_in_owner = true
 texture_filter = 1
+clip_contents = false
 custom_minimum_size = Vector2(59, 17)
 layout_mode = 2
+size_flags_horizontal = 10
 theme = ExtResource("1_5pall")
 theme_type_variation = &"HealthPanelLabel"
 theme_override_styles/normal = SubResource("StyleBoxFlat_uj006")
 text = "345/400"
+fit_content = true
 scroll_active = false
+autowrap_mode = 0
 horizontal_alignment = 1
 vertical_alignment = 1


### PR DESCRIPTION
# Description
 - Prevent text from wrapping if the HP label gets too long
# Screenshot
<img width="1568" height="902" alt="Screenshot 2025-08-07 at 7 18 23 PM" src="https://github.com/user-attachments/assets/dc3ab6b7-ee1a-4729-9000-1b3c64ee1480" />
