### PR TITLE
Enemy tracker

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -48,3 +48,19 @@ ui_pause={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":80,"key_label":0,"unicode":112,"location":0,"echo":false,"script":null)
 ]
 }
+toggle_tracker={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194326,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":9,"pressure":0.0,"pressed":true,"script":null)
+]
+}
+mark_tracker={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(294, 16),"global_position":Vector2(303, 64),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
+switch_tracker={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}

--- a/project.godot
+++ b/project.godot
@@ -62,5 +62,6 @@ mark_tracker={
 switch_tracker={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":10,"pressure":0.0,"pressed":true,"script":null)
 ]
 }

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -412,14 +412,33 @@ texture = ExtResource("18_h4dll")
 [node name="DebugMenu" parent="." instance=ExtResource("19_p0caf")]
 visible = false
 
-[node name="Tracker" parent="." instance=ExtResource("18_p0caf")]
+[node name="Trackers" type="Control" parent="."]
 visible = false
-z_index = 1
-offset_left = 159.0
+z_index = 2
+layout_mode = 3
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="PlayerTracker" parent="Trackers" instance=ExtResource("18_p0caf")]
+unique_name_in_owner = true
+z_index = 2
+layout_mode = 1
+offset_left = 158.0
 offset_top = 9.0
-offset_right = 199.0
+offset_right = 198.0
 offset_bottom = 49.0
 theme = ExtResource("2_p1qf1")
+
+[node name="EnemyTracker" parent="Trackers" instance=ExtResource("18_p0caf")]
+unique_name_in_owner = true
+visible = false
+z_index = 2
+layout_mode = 1
+offset_left = 42.0
+offset_top = 46.0
+offset_right = 82.0
+offset_bottom = 86.0
+isPlayer = false
 
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Attack" to="BattleStateMachine/SELECTING_ACTION" method="_on_attack_pressed"]
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Tracker" to="BattleStateMachine/SELECTING_ACTION" method="_on_tracker_pressed"]

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -416,7 +416,9 @@ visible = false
 visible = false
 z_index = 1
 offset_left = 159.0
+offset_top = 9.0
 offset_right = 199.0
+offset_bottom = 49.0
 theme = ExtResource("2_p1qf1")
 
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Attack" to="BattleStateMachine/SELECTING_ACTION" method="_on_attack_pressed"]

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -438,7 +438,7 @@ offset_left = 42.0
 offset_top = 46.0
 offset_right = 82.0
 offset_bottom = 86.0
-isPlayer = false
+is_player = false
 
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Attack" to="BattleStateMachine/SELECTING_ACTION" method="_on_attack_pressed"]
 [connection signal="pressed" from="BottomBar/Action/ActionButtons/Tracker" to="BattleStateMachine/SELECTING_ACTION" method="_on_tracker_pressed"]

--- a/scenes/shop.tscn
+++ b/scenes/shop.tscn
@@ -346,8 +346,8 @@ unique_name_in_owner = true
 z_index = 1
 layout_mode = 1
 offset_left = 159.0
-offset_top = 40.0
+offset_top = 43.0
 offset_right = 199.0
-offset_bottom = 80.0
+offset_bottom = 83.0
 
 [connection signal="pressed" from="GridContainer/TrinketContainer/ExitButtonRow/ExitButton" to="." method="_on_exit_button_pressed"]

--- a/scenes/tracker.tscn
+++ b/scenes/tracker.tscn
@@ -12,7 +12,7 @@ script = ExtResource("1_g10r1")
 [node name="Panel" type="Panel" parent="."]
 layout_mode = 0
 offset_right = 97.0
-offset_bottom = 72.0
+offset_bottom = 65.0
 
 [node name="TrackerInfo" type="GridContainer" parent="Panel"]
 unique_name_in_owner = true
@@ -24,17 +24,6 @@ offset_bottom = 71.0
 theme_override_constants/h_separation = 0
 theme_override_constants/v_separation = 0
 columns = 2
-
-[node name="Character_Name" type="Label" parent="Panel/TrackerInfo"]
-layout_mode = 2
-theme = ExtResource("1_bfym8")
-theme_type_variation = &"SmallTextLabel"
-text = "Char"
-
-[node name="Placeholder" type="Label" parent="Panel/TrackerInfo"]
-layout_mode = 2
-theme = ExtResource("1_bfym8")
-theme_type_variation = &"SmallTextLabel"
 
 [node name="HP_Info" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -143,3 +132,18 @@ layout_mode = 2
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
 text = "100"
+
+[node name="Panel2" type="Panel" parent="."]
+layout_mode = 0
+offset_top = -9.0
+offset_right = 97.0
+
+[node name="Character_Name" type="Label" parent="Panel2"]
+layout_mode = 0
+offset_left = 1.0
+offset_top = 1.0
+offset_right = 96.0
+offset_bottom = 8.0
+theme = ExtResource("1_bfym8")
+theme_type_variation = &"SmallTextLabel"
+text = "Char"

--- a/scenes/tracker.tscn
+++ b/scenes/tracker.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://tlm6nhptxwkx"]
+[gd_scene load_steps=4 format=3 uid="uid://tlm6nhptxwkx"]
 
 [ext_resource type="Theme" uid="uid://bb5xdt6d0xc8h" path="res://assets/themes/main.tres" id="1_bfym8"]
 [ext_resource type="Script" uid="uid://dqx4yk84nwr8x" path="res://scripts/tracker.gd" id="1_g10r1"]
+[ext_resource type="Script" uid="uid://5gqyd7etib2b" path="res://scripts/mark_tracker.gd" id="3_ocy8l"]
 
 [node name="Tracker" type="Control"]
 layout_mode = 3
@@ -33,9 +34,11 @@ text = "HP:"
 
 [node name="HP" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "0000/0000"
+text = "?/?"
+script = ExtResource("3_ocy8l")
 
 [node name="ATK_Info" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -45,9 +48,11 @@ text = "ATK:"
 
 [node name="ATK" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "0"
+text = "?"
+script = ExtResource("3_ocy8l")
 
 [node name="SP_ATK_Info" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -57,9 +62,11 @@ text = "SP_ATK:"
 
 [node name="SP_ATK" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "0"
+text = "?"
+script = ExtResource("3_ocy8l")
 
 [node name="DEF_Info" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -69,9 +76,11 @@ text = "DEF:"
 
 [node name="DEF" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "0"
+text = "?"
+script = ExtResource("3_ocy8l")
 
 [node name="SP_DEF_INFO" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -81,9 +90,11 @@ text = "SP_DEF:"
 
 [node name="SP_DEF" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "0"
+text = "?"
+script = ExtResource("3_ocy8l")
 
 [node name="SPEED_Info" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -93,9 +104,11 @@ text = "SPEED:"
 
 [node name="SPEED" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "0"
+text = "?"
+script = ExtResource("3_ocy8l")
 
 [node name="LUCK_Info" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -105,9 +118,11 @@ text = "LUCK:"
 
 [node name="LUCK" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "0"
+text = "?"
+script = ExtResource("3_ocy8l")
 
 [node name="CRIT_Info" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -117,9 +132,11 @@ text = "CRIT:"
 
 [node name="CRIT" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "0.00"
+text = "?"
+script = ExtResource("3_ocy8l")
 
 [node name="ACC_Info" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
@@ -129,9 +146,11 @@ text = "ACC:"
 
 [node name="ACC" type="Label" parent="Panel/TrackerInfo"]
 layout_mode = 2
+mouse_filter = 0
 theme = ExtResource("1_bfym8")
 theme_type_variation = &"SmallTextLabel"
-text = "100"
+text = "?"
+script = ExtResource("3_ocy8l")
 
 [node name="Panel2" type="Panel" parent="."]
 layout_mode = 0

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -31,6 +31,7 @@ var previous_state_name: String
 var setup_done := false
 
 # Connected in GameManager
+@warning_ignore("unused_signal")
 signal battle_ended(victory: bool)
 
 @onready var ui_manager: BattleUIManager = %BattleUiManager
@@ -40,6 +41,19 @@ func _ready() -> void:
 	_init_states()
 	_init_backdrop_image()
 	call_deferred("_start_battle")
+	
+
+func _input(event: InputEvent):
+	if event.is_action_pressed("toggle_tracker"):
+		%PlayerTracker.populate_player_tracker()
+		%EnemyTracker.populate_enemy_tracker()
+		$Trackers.visible = not $Trackers.visible
+	if $Trackers.visible and event.is_action_pressed("switch_tracker"):
+		%PlayerTracker.visible = not %PlayerTracker.visible
+		%EnemyTracker.visible = not %EnemyTracker.visible
+	if current_state:
+		current_state.handle_input(event)
+	
 
 func _init_backdrop_image():
 	match GameManager.floor_number:
@@ -164,8 +178,3 @@ func get_attacker():
 
 func _on_continue_button_pressed() -> void:
 	current_state.handle_continue()
-
-
-func _input(event: InputEvent) -> void:
-	if current_state:
-		current_state.handle_input(event)

--- a/scripts/mark_tracker.gd
+++ b/scripts/mark_tracker.gd
@@ -1,0 +1,21 @@
+extends Label
+class_name MarkTracker
+
+var click_counter = 0
+
+func _gui_input(event: InputEvent) -> void:
+	# TODO: Make this do-able with controller - be able to cycle through enemy tracker and press RB to switch the marking. 
+	if event.is_action_pressed("mark_tracker") and not get_parent().get_parent().get_parent().is_player:
+		click_counter += 1
+		if click_counter > 3:
+			click_counter = 1
+		match click_counter:
+			1:
+				text = "+"
+				add_theme_color_override("font_color", Color.GREEN)
+			2:
+				text = "="
+				add_theme_color_override("font_color", Color.WHITE)
+			3:
+				text = "-"
+				add_theme_color_override("font_color", Color.RED)

--- a/scripts/mark_tracker.gd.uid
+++ b/scripts/mark_tracker.gd.uid
@@ -1,0 +1,1 @@
+uid://5gqyd7etib2b

--- a/scripts/monster.gd
+++ b/scripts/monster.gd
@@ -142,8 +142,8 @@ func use_move(move: Move, target: Monster) -> AttackResults:
 	if status_effect == MovesList.StatusEffect.WHIRLPOOL:
 		# Whirlpool has a 50% chance to damage the affected character each turn
 		var whirlpool_activation_chance = 50
-		move_hit = _does_move_crit_or_status(whirlpool_activation_chance)
-		if move_hit:
+		var whirlpool_activated = _does_move_crit_or_status(whirlpool_activation_chance)
+		if whirlpool_activated:
 			move = GameManager.get_move_by_name("Whirlpool")
 			@warning_ignore("confusable_local_declaration")
 			var results = _attack(move, self, 1)

--- a/scripts/states/Attack.gd
+++ b/scripts/states/Attack.gd
@@ -26,7 +26,7 @@ func enter(params: Array = []):
 	if GameManager.player.selected_monster.invincible and target == GameManager.player.selected_monster:
 		messages.append("DEBUG: Player takes no damage")
 		
-	battle.get_node("Tracker").populate_player_tracker()
+	battle.get_node("Trackers/PlayerTracker").populate_player_tracker()
 
 	# Transition to AttackingInfoState to show results
 	battle.transition_state_to(battle.STATE_INFO, messages)

--- a/scripts/states/Attack.gd
+++ b/scripts/states/Attack.gd
@@ -25,6 +25,8 @@ func enter(params: Array = []):
 	# if the debug setting is enabled, mention it
 	if GameManager.player.selected_monster.invincible and target == GameManager.player.selected_monster:
 		messages.append("DEBUG: Player takes no damage")
+		
+	battle.get_node("Tracker").populate_player_tracker()
 
 	# Transition to AttackingInfoState to show results
 	battle.transition_state_to(battle.STATE_INFO, messages)

--- a/scripts/states/SelectingAction.gd
+++ b/scripts/states/SelectingAction.gd
@@ -28,6 +28,6 @@ func _on_attack_pressed() -> void:
 
 
 func _on_tracker_pressed() -> void:
-	var tracker = battle.get_node("Tracker")
-	tracker.populate_player_tracker()
-	tracker.visible = !tracker.visible
+	battle.get_node("Trackers/PlayerTracker").populate_player_tracker()
+	battle.get_node("Trackers/EnemyTracker").populate_enemy_tracker()
+	battle.get_node("Trackers").visible = not battle.get_node("Trackers").visible

--- a/scripts/tracker.gd
+++ b/scripts/tracker.gd
@@ -1,6 +1,8 @@
 extends Control
 class_name Tracker
 
+@export var is_player := true
+
 func populate_player_tracker():
 	$Panel2/Character_Name.text = GameManager.player.selected_monster.character_name
 	$Panel/TrackerInfo/HP.text = "%d/%d" % [GameManager.player.selected_monster.hp, GameManager.player.selected_monster.max_hp]
@@ -12,3 +14,7 @@ func populate_player_tracker():
 	$Panel/TrackerInfo/LUCK.text = str(GameManager.player.selected_monster.luck)
 	$Panel/TrackerInfo/CRIT.text = str(GameManager.player.selected_monster.crit_chance) + "(%d)" % GameManager.player.selected_monster.crit_checks
 	$Panel/TrackerInfo/ACC.text = str(GameManager.player.selected_monster.acc)
+
+
+func populate_enemy_tracker():
+	$Panel2/Character_Name.text = GameManager.enemy.selected_monster.character_name

--- a/scripts/tracker.gd
+++ b/scripts/tracker.gd
@@ -2,7 +2,7 @@ extends Control
 class_name Tracker
 
 func populate_player_tracker():
-	$Panel/TrackerInfo/Character_Name.text = GameManager.player.selected_monster.character_name
+	$Panel2/Character_Name.text = GameManager.player.selected_monster.character_name
 	$Panel/TrackerInfo/HP.text = "%d/%d" % [GameManager.player.selected_monster.hp, GameManager.player.selected_monster.max_hp]
 	$Panel/TrackerInfo/ATK.text = str(GameManager.player.selected_monster.atk)
 	$Panel/TrackerInfo/SP_ATK.text = str(GameManager.player.selected_monster.sp_atk)
@@ -10,5 +10,5 @@ func populate_player_tracker():
 	$Panel/TrackerInfo/SP_DEF.text = str(GameManager.player.selected_monster.sp_def)
 	$Panel/TrackerInfo/SPEED.text = str(GameManager.player.selected_monster.speed)
 	$Panel/TrackerInfo/LUCK.text = str(GameManager.player.selected_monster.luck)
-	$Panel/TrackerInfo/CRIT.text = str(GameManager.player.selected_monster.crit_chance)
+	$Panel/TrackerInfo/CRIT.text = str(GameManager.player.selected_monster.crit_chance) + "(%d)" % GameManager.player.selected_monster.crit_checks
 	$Panel/TrackerInfo/ACC.text = str(GameManager.player.selected_monster.acc)


### PR DESCRIPTION
# Implemented enemy tracker
- Press CTRL to toggle visibility
- Press SHIFT to toggle between the player/enemy tracker
- Click on any of the stats to mark high, medium, or low

Video:
[2025-08-07 18-08-09.zip](https://github.com/user-attachments/files/21675234/2025-08-07.18-08-09.zip)

# TODO (On a seperate branch)
- Each enemy will likely need its own tracker, to save info upon coming across that enemy again. Right now there is only one enemy tracker that stays the same when enemies switch. 
- There needs to be a way to mark high/medium/low and navigate between the tracker stats on controller