### PR TITLE
WIP: Add Death Animation

### DIFF
--- a/assets/shaders/outline-material.tres
+++ b/assets/shaders/outline-material.tres
@@ -1,13 +1,17 @@
 [gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://cylohngiemf5m"]
 
-[ext_resource type="Shader" path="res://assets/shaders/outline.gdshader" id="1_ly5mf"]
+[ext_resource type="Shader" uid="uid://cwjiowobjkvf" path="res://assets/shaders/outline.gdshader" id="1_ly5mf"]
 
 [resource]
 resource_local_to_scene = true
 shader = ExtResource("1_ly5mf")
 shader_parameter/color = Color(1, 1, 1, 1)
-shader_parameter/width = 1.0
-shader_parameter/pattern = 0
+shader_parameter/width = 2.0
+shader_parameter/pattern = 1
 shader_parameter/inside = false
 shader_parameter/add_margins = false
 shader_parameter/number_of_images = Vector2(1, 1)
+shader_parameter/slice_direction = Vector2(0, 0.5)
+shader_parameter/slice_effect_offset = 0.0
+shader_parameter/fade = 1.0
+shader_parameter/strip = 4.0

--- a/assets/shaders/outline.gdshader
+++ b/assets/shaders/outline.gdshader
@@ -10,6 +10,15 @@ uniform vec2 number_of_images = vec2(1.0); // number of horizontal and vertical 
 
 varying flat vec4 modulate;
 
+// original source for slice effect: https://godotshaders.com/shader/slice-and-fade-out/
+uniform vec2 slice_direction = vec2(.0, .5);
+
+uniform float slice_effect_offset : hint_range(0., 1.);
+
+uniform float fade : hint_range(0., 1.);
+
+uniform float strip = 4.;
+
 void vertex() {
 	modulate = COLOR;
 
@@ -53,6 +62,12 @@ void fragment() {
 	vec2 image_top_left = floor(uv * number_of_images) / number_of_images;
 	vec2 image_bottom_right = image_top_left + vec2(1.0) / number_of_images;
 
+	vec2 norm = normalize(slice_direction);
+	vec2 pixels = SCREEN_UV / SCREEN_PIXEL_SIZE;
+	vec2 pdir = vec2(norm.y, -norm.x);
+	uv = uv + ((float(int(dot(pdir, pixels) / strip) & 0x1) * 2.) - 1.) * slice_effect_offset * pdir;
+
+
 	if (add_margins) {
 		vec2 texture_pixel_size = vec2(1.0) / (vec2(1.0) / TEXTURE_PIXEL_SIZE + vec2(width * 2.0) * number_of_images);
 
@@ -71,4 +86,10 @@ void fragment() {
 		COLOR.rgb = inside ? mix(COLOR.rgb, color.rgb * modulate.rgb, color.a * modulate.a) : color.rgb * modulate.rgb;
 		COLOR.a += (1.0 - COLOR.a) * color.a * modulate.a;
 	}
+
+
+	//vec4 second_effect_color = texture(TEXTURE, corrected_uv);
+	COLOR.a *= clamp(1. - slice_effect_offset/fade, 0., 1.);
+
+	//COLOR = second_effect_color;
 }

--- a/scenes/battle_participant.tscn
+++ b/scenes/battle_participant.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=9 format=3 uid="uid://dspy5d5yn1fxj"]
+[gd_scene load_steps=11 format=3 uid="uid://dspy5d5yn1fxj"]
 
 [ext_resource type="Script" uid="uid://d0ejnncl5rkg0" path="res://scripts/battle_participant.gd" id="1_3vyb7"]
 [ext_resource type="PackedScene" uid="uid://cngw2ls1edyyl" path="res://scenes/status_emitter.tscn" id="3_dmbjg"]
+[ext_resource type="Material" uid="uid://cylohngiemf5m" path="res://assets/shaders/outline-material.tres" id="3_i87j4"]
 [ext_resource type="Texture2D" uid="uid://ccw3gkgcfoqh0" path="res://assets/sprites/characters/omenite.png" id="4_07hmd"]
 [ext_resource type="Shader" uid="uid://cwjiowobjkvf" path="res://assets/shaders/outline.gdshader" id="4_i87j4"]
 
@@ -14,9 +15,14 @@ shader_parameter/pattern = 0
 shader_parameter/inside = false
 shader_parameter/add_margins = false
 shader_parameter/number_of_images = Vector2(1, 1)
+shader_parameter/slice_direction = Vector2(0, 0.5)
+shader_parameter/slice_effect_offset = 0.0
+shader_parameter/fade = 0.0
+shader_parameter/strip = 4.0
 
 [sub_resource type="Animation" id="Animation_i87j4"]
 length = 0.001
+step = 0.1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -29,10 +35,23 @@ tracks/0/keys = {
 "update": 0,
 "values": [Vector2(0, 0)]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:material:shader_parameter/slice_effect_offset")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
 
 [sub_resource type="Animation" id="Animation_07hmd"]
 resource_name = "attack_shake"
 length = 0.33333668
+step = 0.1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -46,15 +65,33 @@ tracks/0/keys = {
 "values": [Vector2(0, 0), Vector2(-24, 0), Vector2(24, 0), Vector2(-24, 0), Vector2(24, 0), Vector2(-24, 0), Vector2(0, 0)]
 }
 
+[sub_resource type="Animation" id="Animation_eng1k"]
+resource_name = "horiz_slice"
+step = 0.1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:material:shader_parameter/slice_effect_offset")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 1.0]
+}
+
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_eng1k"]
 _data = {
 &"RESET": SubResource("Animation_i87j4"),
-&"attack_shake": SubResource("Animation_07hmd")
+&"attack_shake": SubResource("Animation_07hmd"),
+&"horiz_slice": SubResource("Animation_eng1k")
 }
 
 [node name="BattleParticipant" type="Sprite2D"]
 z_index = 1
 texture_filter = 1
+material = ExtResource("3_i87j4")
 texture = ExtResource("4_07hmd")
 flip_h = true
 script = ExtResource("1_3vyb7")
@@ -71,7 +108,6 @@ emission_sphere_radius = 24.0
 direction = Vector2(0, 0)
 spread = 90.0
 gravity = Vector2(0, -250)
-status_effect = null
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/scripts/battle_participant.gd
+++ b/scripts/battle_participant.gd
@@ -26,6 +26,16 @@ var selected_monster: Monster:
 		selected_monster.connect("attack_used", play_attack_animation)
 		render_battler()
 
+func play_death_animation():
+	var ap: AnimationPlayer = $AnimationPlayer
+
+	ap.play("horiz_slice")
+	ap.connect("animation_finished", func(anim_name):
+		if anim_name == "horiz_slice":
+			hide()
+			ap.play("RESET")
+	)
+
 func play_attack_animation():
 	var ap: AnimationPlayer = $AnimationPlayer
 
@@ -54,6 +64,7 @@ func render_battler():
 	flip_h = is_player
 	$StatusEmitter.status_effect = selected_monster.status_effect
 
+
 func is_defeated() -> bool:
 	if is_player:
 		if selected_monster.hp > 0:
@@ -62,6 +73,7 @@ func is_defeated() -> bool:
 		for monster in monsters:
 			if monster.hp > 0:
 				return false
+
 	return true
 
 
@@ -72,3 +84,4 @@ func swap_dead_monster():
 		if monsters.size() == 0:
 			return
 		selected_monster = monsters[0]
+		show()

--- a/scripts/states/IncrementTurn.gd
+++ b/scripts/states/IncrementTurn.gd
@@ -64,10 +64,14 @@ func _check_for_dead_monsters() -> String:
 	var message = ""
 	if enemy.selected_monster.hp <= 0 and player.selected_monster.hp <= 0:
 		message = "%s and %s wiped each other out!" % [enemy.selected_monster.character_name, player.selected_monster.character_name]
+		enemy.play_death_animation()
+		player.play_death_animation()
 	elif enemy.selected_monster.hp <= 0:
 		message = "%s defeated %s!" % [player.selected_monster.character_name, enemy.selected_monster.character_name]
+		enemy.play_death_animation()
 	elif player.selected_monster.hp <= 0:
 		message = "%s defeated %s!" % [enemy.selected_monster.character_name, player.selected_monster.character_name]
+		player.play_death_animation()
 
 	return message
 


### PR DESCRIPTION
# Description
 - Update outline shader to contain a "Slice and Fade out" shader: https://godotshaders.com/shader/slice-and-fade-out/
 - By animating the `offset` field of this shader, we can create a death animation

[Screen Recording 2025-08-08 at 11.32.05 AM.webm](https://github.com/user-attachments/assets/5f46a75b-ab8e-4b86-8e76-6d76da071dd6)

# TODO
 - there are some timing issues that mean the sprite can stay hidden if you click too quickly