### PR TITLE
UI: Add Water Shader to Backdrop on Second Floor

### DIFF
--- a/assets/shaders/water-material.tres
+++ b/assets/shaders/water-material.tres
@@ -1,0 +1,18 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://uxf5hi4ymdv6"]
+
+[ext_resource type="Shader" uid="uid://cg5njcp7k8g6k" path="res://assets/shaders/water.gdshader" id="1_dl0ts"]
+
+[resource]
+shader = ExtResource("1_dl0ts")
+shader_parameter/hFrames = 1
+shader_parameter/vFrames = 1
+shader_parameter/enableMovement = true
+shader_parameter/displacementPixels = 2
+shader_parameter/timeGap = 0.32999999262384005
+shader_parameter/speed = 0.33000000000174623
+shader_parameter/leftSideRelationTime = 0.43999999016512004
+shader_parameter/rightSideRelationTime = 0.32999999262384005
+shader_parameter/color = Color(1, 1, 1, 1)
+shader_parameter/colorMix = 0.0
+shader_parameter/alpha = 0.9999999776480001
+shader_parameter/mask = Color(0, 0.6, 0.858824, 1)

--- a/assets/shaders/water.gdshader
+++ b/assets/shaders/water.gdshader
@@ -1,0 +1,99 @@
+//Original source: https://godotshaders.com/shader/sprite-water-reflection-pixel-art/
+//
+// I have updated the original shader
+
+shader_type canvas_item;
+
+uniform int hFrames = 1; //Number of horizontal frames in the Texture
+uniform int vFrames = 1; //Number of vertical frames in the Texture
+
+group_uniforms Displacement;
+uniform bool enableMovement = true;
+uniform int displacementPixels = 1; // Number of pixels to displace
+
+uniform float timeGap : hint_range(0.0, 1.0, 0.01) = 0.4; // Time in seconds that Left side movement will wait to move
+
+uniform float speed = 1.25; // Movement speed
+/*
+SideRelationTime determines the time ratio spent in each step.
+For example, with a value of 0.25, a quarter of the time is spent in the normal position,
+and the remaining three-quarters in the shifted position.
+*/
+uniform float leftSideRelationTime : hint_range(0.0, 1.0, 0.01) = 0.3;
+uniform float rightSideRelationTime : hint_range(0.0, 1.0, 0.01) = 0.3;
+
+group_uniforms Color;
+uniform vec3 color: source_color = vec3(1.0);
+uniform float colorMix: hint_range(0.0, 1.0, 0.01) = 0.0;
+uniform float alpha: hint_range(0.0, 1.0, 0.01) = 1.0;
+
+// The shader will only affect the parts of the underlying texture which match
+// the mask color.
+//
+// This is not part of the original shader -- this is a custom modification
+uniform vec4 mask: source_color = vec4(1.0);
+
+float ShiftPixels(float uvX, float normalizedUvX, float shift) {
+  if (normalizedUvX <= 0.5) {
+    //left side
+    uvX -= shift * step(mod((TIME + timeGap) * speed, 1.0), leftSideRelationTime);
+  }
+  else {
+    //right side
+    uvX -= shift * step(mod(TIME * speed, 1.0), rightSideRelationTime);
+  }
+
+  return uvX;
+}
+
+// We have to resize the sprite so it is not cut
+void vertex(){
+  switch (VERTEX_ID){
+    case 0:
+      VERTEX.x -= float(displacementPixels);
+      break;
+    case 1:
+      VERTEX.x -= float(displacementPixels);
+      break;
+    case 2:
+      VERTEX.x += float(displacementPixels);
+      break;
+    case 3:
+      VERTEX.x += float(displacementPixels);
+      break;
+  }
+}
+
+vec2 AdjustUvToNewSize(vec2 originalUV, float texturePixelSizeX, vec2 numberFrames, float frameX) {
+  // relation between the previous size and the new one
+  float relation = (1.0 + 2.0 * texturePixelSizeX * float(displacementPixels) * numberFrames.x);
+
+  vec2 uv = originalUV;
+
+  uv.x *= relation;
+
+  // adapt new position to new uv
+  uv.x -= float(displacementPixels) * texturePixelSizeX * (1.0 + frameX * numberFrames.x / 2.0);
+
+  return uv;
+}
+
+void fragment() {
+  vec2 numberFrames = vec2(float(hFrames), float(vFrames));
+  vec2 normalizedUv = mod(UV * numberFrames, vec2(1.0));
+  float frameX = floor(UV.x * numberFrames.x);
+
+  vec4 base_color = texture(TEXTURE, UV);
+  if (length(base_color - mask) < 0.1) {
+
+    vec2 uv = AdjustUvToNewSize(UV, TEXTURE_PIXEL_SIZE.x, numberFrames, frameX);
+
+    if (enableMovement) {
+      uv.x = ShiftPixels(uv.x, normalizedUv.x, TEXTURE_PIXEL_SIZE.x * float(displacementPixels));
+    }
+
+    COLOR = texture(TEXTURE, uv);
+    COLOR.rgb = mix(COLOR.rgb, color, colorMix);
+    COLOR.a *= alpha;
+  }
+}

--- a/assets/shaders/water.gdshader.uid
+++ b/assets/shaders/water.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cg5njcp7k8g6k

--- a/scenes/battle.tscn
+++ b/scenes/battle.tscn
@@ -36,6 +36,7 @@ script = ExtResource("1_a12nh")
 [node name="Backdrop" type="Sprite2D" parent="."]
 unique_name_in_owner = true
 z_index = -1
+texture_filter = 1
 position = Vector2(128, 72)
 texture = ExtResource("1_dn72j")
 

--- a/scripts/battle.gd
+++ b/scripts/battle.gd
@@ -40,9 +40,11 @@ signal battle_ended(victory: bool)
 
 func _ready() -> void:
 	_init_states()
-	_init_backdrop_image()
+	call_deferred("_init_ui")
 	call_deferred("_start_battle")
-	
+
+func _init_ui():
+	ui_manager.init_backdrop_image()
 
 func _input(event: InputEvent):
 	if event.is_action_pressed("toggle_tracker"):
@@ -54,26 +56,6 @@ func _input(event: InputEvent):
 		%EnemyTracker.visible = not %EnemyTracker.visible
 	if current_state:
 		current_state.handle_input(event)
-	
-
-func _init_backdrop_image():
-	match GameManager.floor_number:
-		1:
-			%Backdrop.texture = load("res://assets/sprites/backdrops/earth_backdrop.png")
-		2:
-			%Backdrop.texture = load("res://assets/sprites/backdrops/water_backdrop.png")
-		3:
-			%Backdrop.texture = load("res://assets/sprites/backdrops/fire_backdrop.png")
-		4:
-			%Backdrop.texture = load("res://assets/sprites/backdrops/air_backdrop.png")
-		5:
-			%Backdrop.texture = load("res://assets/sprites/backdrops/ether_backdrop.png")
-		6:
-			%Backdrop.texture = load("res://assets/sprites/backdrops/light_backdrop.png")
-		7:
-			%Backdrop.texture = load("res://assets/sprites/backdrops/cosmic_backdrop.png")
-		_:
-			%Backdrop.texture = load("res://assets/sprites/backdrops/earth_backdrop.png")
 
 
 func setup(_player: BattleParticipant, _enemy: BattleParticipant):

--- a/scripts/battle_ui_manager.gd
+++ b/scripts/battle_ui_manager.gd
@@ -40,8 +40,33 @@ func set_backdrop_material(material: ShaderMaterial):
 	backdrop.material = material
 
 
-func clear_backdrop_material():
+func reset_backdrop_material():
+	if GameManager.floor_number == 2:
+		backdrop.material = load("res://assets/shaders/water-material.tres")
+		return
+
 	backdrop.material = null
+
+# TODO: move to battle UI manager
+func init_backdrop_image():
+	reset_backdrop_material()
+	match GameManager.floor_number:
+		1:
+			%Backdrop.texture = load("res://assets/sprites/backdrops/earth_backdrop.png")
+		2:
+			%Backdrop.texture = load("res://assets/sprites/backdrops/water_backdrop.png")
+		3:
+			%Backdrop.texture = load("res://assets/sprites/backdrops/fire_backdrop.png")
+		4:
+			%Backdrop.texture = load("res://assets/sprites/backdrops/air_backdrop.png")
+		5:
+			%Backdrop.texture = load("res://assets/sprites/backdrops/ether_backdrop.png")
+		6:
+			%Backdrop.texture = load("res://assets/sprites/backdrops/light_backdrop.png")
+		7:
+			%Backdrop.texture = load("res://assets/sprites/backdrops/cosmic_backdrop.png")
+		_:
+			%Backdrop.texture = load("res://assets/sprites/backdrops/earth_backdrop.png")
 
 
 func render_hp(player_monster, enemy_monster):

--- a/scripts/states/Info.gd
+++ b/scripts/states/Info.gd
@@ -22,7 +22,7 @@ func enter(_messages: Array = []):
 
 
 func exit():
-	battle.ui_manager.clear_backdrop_material()
+	battle.ui_manager.reset_backdrop_material()
 	battle.ui_manager.show_info_panel(false)
 
 


### PR DESCRIPTION
# Description

 - uses a slightly modified version of [Sprite Water Reflection Pixel Art Pokemon Style](https://godotshaders.com/shader/sprite-water-reflection-pixel-art/) shader to add water-like movement to the backdrop on the second floor


# Demo

[Screen Recording 2025-08-08 at 4.13.31 PM.webm](https://github.com/user-attachments/assets/e713fc9a-131c-483b-a119-bbbb8062bf29)
