### PR TITLE
Fix: Update `Monster._check_status_immunity()` to respect current types

### DIFF
--- a/scripts/monster.gd
+++ b/scripts/monster.gd
@@ -245,22 +245,25 @@ func _roll_and_apply_status_effect(move: Move, target: Monster) -> bool:
 
 func _check_status_immunity(effect: MovesList.StatusEffect, target_type: MovesList.Type):
 	match effect:
-		MovesList.StatusEffect.BURN:
-			if target_type == MovesList.Type.FIRE:
+		MovesList.StatusEffect.POISON:
+			if target_type == MovesList.Type.EARTH:
 				return true
 		MovesList.StatusEffect.WHIRLPOOL:
 			if target_type == MovesList.Type.WATER:
 				return true
-		MovesList.StatusEffect.POISON:
-			if target_type == MovesList.Type.AIR:
+		MovesList.StatusEffect.BURN:
+			if target_type == MovesList.Type.FIRE:
 				return true
 		MovesList.StatusEffect.EXPOSE:
+			if target_type == MovesList.Type.AIR:
+				return true
+		MovesList.StatusEffect.VACUUM:
 			if target_type == MovesList.Type.ETHER:
 				return true
 		MovesList.StatusEffect.BLIND:
 			if target_type == MovesList.Type.LIGHT:
 				return true
-		MovesList.StatusEffect.VACUUM:
+		MovesList.StatusEffect.UNVEIL:
 			if target_type == MovesList.Type.COSMIC:
 				return true
 	return false


### PR DESCRIPTION
## Description
 - Fixes #118
 - When we updated the palettes and types a while back, we failed to update `Monster._check_status_immunity`

## Screenshots
<img width="1564" height="896" alt="Screenshot 2025-08-11 at 6 50 09 PM" src="https://github.com/user-attachments/assets/4eac4044-d052-4ee9-bed1-dcbc3bf787ab" />
